### PR TITLE
fix(cli): run command line mode without a GUI stack

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,6 +208,10 @@ public:
 #include <QLocalServer>
 #include <QLocalSocket>
 
+#ifndef ASTRA_VERSION
+#define ASTRA_VERSION "1.1.0"
+#endif
+
 int main(int argc, char* argv[]) {
     qputenv("QML_XHR_ALLOW_FILE_READ", "1");
     bool launchGui = false;
@@ -255,6 +259,16 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    if (!launchGui) {
+        QCoreApplication app(argc, argv);
+        app.setApplicationName(QStringLiteral("astra"));
+        app.setOrganizationName(QStringLiteral("AstraMarket"));
+        app.setApplicationVersion(QStringLiteral(ASTRA_VERSION));
+
+        PackageManager pm;
+        return CliHandler::run(argc, argv, pm);
+    }
+
     QSurfaceFormat format;
     format.setRedBufferSize(8);
     format.setGreenBufferSize(8);
@@ -264,21 +278,12 @@ int main(int argc, char* argv[]) {
     format.setStencilBufferSize(8);
     QSurfaceFormat::setDefaultFormat(format);
 
-#ifndef ASTRA_VERSION
-#define ASTRA_VERSION "1.1.0"
-#endif
-
     QApplication app(argc, argv);
     app.setApplicationName(QStringLiteral("astra"));
     app.setOrganizationName(QStringLiteral("AstraMarket"));
     app.setDesktopFileName(QStringLiteral("astra"));
     app.setApplicationVersion(QStringLiteral(ASTRA_VERSION));
     app.setQuitOnLastWindowClosed(false);
-
-    if (!launchGui) {
-        PackageManager pm;
-        return CliHandler::run(argc, argv, pm);
-    }
 
     const QString iconPath = QStringLiteral(":/assets/icons/AstraMarket.svg");
     if (QFile::exists(iconPath)) {


### PR DESCRIPTION
## Problem

`main()` constructs a `QApplication` before it dispatches to `CliHandler`, so every non-GUI invocation needs a display server. On a TTY or over SSH the process aborts before printing anything:

```
$ env -u DISPLAY -u WAYLAND_DISPLAY astra --version
Aborted (core dumped)   # rc=134
```

That affects all CLI commands (`search`, `install`, `list`, `update`, `info`, `sources`, `--help`, `--version`), i.e. the whole command line half of the project is unusable outside a graphical session.

## Change

- Command line mode now creates a `QCoreApplication` and returns before any GUI type is touched.
- `QSurfaceFormat` setup and `QApplication` construction moved into the GUI path.
- `ASTRA_VERSION` fallback moved to file scope so both paths can use it.

No behaviour change for `--gui` / `--tray`, and the AppImage argument handling (used by the `MimeType=` association in `astra.desktop`) still runs before either path.

## Testing

Built with `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build` on Arch, Qt 6.11.2.

Headless (`env -u DISPLAY -u WAYLAND_DISPLAY`), all rc=0 with correct output: `--version`, `--help`, `sources`, `search vlc`, `list`, `info bash --source Pacman`, `update`.

GUI (`--gui` under Hyprland/Wayland) still starts and renders as before.
