### PR TITLE
fix(plugins): stop passing plugin command values through the shell

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -44,8 +44,32 @@ Each plugin directory must contain a `plugin.json` manifest file and any associa
 - `name` (string, required): Human-readable display name.
 - `description` (string, optional): Short summary of the provider.
 - `icon` (string, optional): Material icon identifier (e.g. `extension`, `download`, `wallpaper`).
-- `requiredBinary` (string, optional): Executable that must be available in PATH or system for the plugin to be active.
+- `requiredBinary` (string, optional): Executable that must exist for the plugin to be active. A plain name is looked up in `PATH`, a value containing a slash is treated as an absolute path.
 - `commands` (object, required): Shell commands executed for respective actions. Variable placeholders `${QUERY}`, `${ID}`, `${SCOPE}` are substituted at runtime.
+
+### Placeholder Substitution
+
+Commands run through `/bin/sh -c`. Placeholders are **not** pasted into the command string: every
+`${NAME}` is rewritten to a positional parameter and the value is handed to the shell as an argument, so
+user input such as a search query is never interpreted as shell syntax.
+
+```json
+"search": "./search.sh \"${QUERY}\""
+```
+
+runs as `/bin/sh -c './search.sh "${1}"' astra-plugin <query>`, and `./search.sh` receives the query
+verbatim in `$1`. Quoting the placeholder in the manifest is still recommended so values containing
+whitespace stay a single argument.
+
+Available placeholders are `${QUERY}` (search), `${ID}` (install, uninstall, details, launch) and the
+install options, currently `${SCOPE}`. Unknown placeholders expand to an empty argument.
+
+### Exit Codes and Timeouts
+
+`install` and `uninstall` are reported as successful only when the command exits with status `0`;
+everything they print on stdout is streamed into the operation log while they run. Metadata commands
+(`search`, `list`, `updates`, `details`) are given 20 seconds before they are terminated, install and
+uninstall are allowed to run for up to an hour, and `launch` is started detached without waiting.
 
 ## Expected JSON Outputs
 

--- a/src/marketplace/plugins/scriptableplugin.cpp
+++ b/src/marketplace/plugins/scriptableplugin.cpp
@@ -1,10 +1,17 @@
 #include "scriptableplugin.hpp"
-#include <QFile>
 #include <QDir>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QJsonArray>
 #include <QProcess>
+#include <QRegularExpression>
+#include <QStandardPaths>
+
+namespace {
+constexpr int kOperationTimeoutMs = 3600000;
+}
 
 ScriptablePlugin::ScriptablePlugin(const QString& manifestPath, QObject* parent)
     : IPackagePlugin(parent), m_manifestPath(manifestPath) {
@@ -32,7 +39,9 @@ ScriptablePlugin::ScriptablePlugin(const QString& manifestPath, QObject* parent)
 
             QString checkBin = obj.value(QStringLiteral("requiredBinary")).toString();
             if (!checkBin.isEmpty()) {
-                m_isAvailable = QFile::exists(checkBin) || QFile::exists(QStringLiteral("/usr/bin/") + checkBin);
+                m_isAvailable = checkBin.contains(QLatin1Char('/'))
+                    ? QFile::exists(checkBin)
+                    : !QStandardPaths::findExecutable(checkBin).isEmpty();
             }
         }
     }
@@ -48,27 +57,94 @@ void ScriptablePlugin::setEnabled(bool enabled) {
     }
 }
 
-QByteArray ScriptablePlugin::runCommand(const QString& cmdTemplate, const QMap<QString, QString>& vars, ProgressCallback progressCb) {
-    if (cmdTemplate.isEmpty()) return QByteArray();
+QStringList ScriptablePlugin::buildShellArguments(const QString& cmdTemplate, const QMap<QString, QString>& vars) {
+    static const QRegularExpression placeholder(QStringLiteral(R"(\$\{([A-Za-z_][A-Za-z0-9_]*)\})"));
 
-    QString cmd = cmdTemplate;
-    for (auto it = vars.begin(); it != vars.end(); ++it) {
-        cmd.replace(QLatin1String("${") + it.key() + QLatin1String("}"), it.value());
+    QString script;
+    QStringList positional;
+    QMap<QString, int> indices;
+    qsizetype cursor = 0;
+
+    QRegularExpressionMatchIterator it = placeholder.globalMatch(cmdTemplate);
+    while (it.hasNext()) {
+        const QRegularExpressionMatch match = it.next();
+        script += cmdTemplate.mid(cursor, match.capturedStart() - cursor);
+
+        const QString name = match.captured(1);
+        int index = indices.value(name, 0);
+        if (index == 0) {
+            positional.append(vars.value(name));
+            index = positional.size();
+            indices.insert(name, index);
+        }
+
+        script += QStringLiteral("${") + QString::number(index) + QStringLiteral("}");
+        cursor = match.capturedEnd();
     }
+    script += cmdTemplate.mid(cursor);
+
+    QStringList args{QStringLiteral("-c"), script, QStringLiteral("astra-plugin")};
+    args.append(positional);
+    return args;
+}
+
+ScriptablePlugin::ScriptResult ScriptablePlugin::runCommand(const QString& cmdTemplate, const QMap<QString, QString>& vars, ProgressCallback progressCb, int timeoutMs) {
+    ScriptResult result;
+    if (cmdTemplate.isEmpty()) return result;
 
     QProcess proc;
     proc.setWorkingDirectory(m_baseDir);
-
-    if (progressCb) {
-        QObject::connect(&proc, &QProcess::readyReadStandardOutput, [&proc, &progressCb]() {
-            QString line = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-            progressCb(50, line);
-        });
+    proc.start(QStringLiteral("/bin/sh"), buildShellArguments(cmdTemplate, vars));
+    if (!proc.waitForStarted(5000)) {
+        proc.kill();
+        proc.waitForFinished(1000);
+        return result;
     }
 
-    proc.start(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), cmd});
-    proc.waitForFinished(10000);
-    return proc.readAllStandardOutput();
+    QElapsedTimer elapsed;
+    elapsed.start();
+    QByteArray pending;
+
+    auto drain = [&](bool flush) {
+        const QByteArray chunk = proc.readAllStandardOutput();
+        if (!chunk.isEmpty()) {
+            result.output.append(chunk);
+            if (progressCb) pending.append(chunk);
+        }
+        result.error.append(proc.readAllStandardError());
+
+        if (!progressCb) return;
+        while (true) {
+            const qsizetype breakAt = pending.indexOf('\n');
+            if (breakAt < 0) break;
+            const QString line = QString::fromUtf8(pending.left(breakAt)).trimmed();
+            pending.remove(0, breakAt + 1);
+            if (!line.isEmpty()) progressCb(50, line);
+        }
+        if (flush && !pending.isEmpty()) {
+            const QString line = QString::fromUtf8(pending).trimmed();
+            pending.clear();
+            if (!line.isEmpty()) progressCb(50, line);
+        }
+    };
+
+    while (proc.state() == QProcess::Running) {
+        proc.waitForReadyRead(200);
+        drain(false);
+
+        if (timeoutMs > 0 && elapsed.hasExpired(timeoutMs)) {
+            result.timedOut = true;
+            proc.kill();
+            proc.waitForFinished(1000);
+            break;
+        }
+    }
+
+    proc.waitForFinished(1000);
+    drain(true);
+
+    result.exitCode = result.timedOut ? -1 : proc.exitCode();
+    return result;
 }
 
 QVariantList ScriptablePlugin::search(const QString& query, const QVariantMap& options) {
@@ -78,9 +154,9 @@ QVariantList ScriptablePlugin::search(const QString& query, const QVariantMap& o
 
     QMap<QString, QString> vars;
     vars[QStringLiteral("QUERY")] = query;
-    QByteArray out = runCommand(m_searchCmd, vars);
+    const ScriptResult result = runCommand(m_searchCmd, vars);
 
-    QJsonDocument doc = QJsonDocument::fromJson(out);
+    QJsonDocument doc = QJsonDocument::fromJson(result.output);
     if (doc.isArray()) {
         for (const QJsonValue& val : doc.array()) {
             if (val.isObject()) {
@@ -98,8 +174,8 @@ QVariantList ScriptablePlugin::getInstalled() {
     QVariantList results;
     if (!m_enabled || m_listCmd.isEmpty()) return results;
 
-    QByteArray out = runCommand(m_listCmd, {});
-    QJsonDocument doc = QJsonDocument::fromJson(out);
+    const ScriptResult result = runCommand(m_listCmd, {});
+    QJsonDocument doc = QJsonDocument::fromJson(result.output);
     if (doc.isArray()) {
         for (const QJsonValue& val : doc.array()) {
             if (val.isObject()) {
@@ -117,8 +193,8 @@ QVariantList ScriptablePlugin::getUpdates() {
     QVariantList results;
     if (!m_enabled || m_updatesCmd.isEmpty()) return results;
 
-    QByteArray out = runCommand(m_updatesCmd, {});
-    QJsonDocument doc = QJsonDocument::fromJson(out);
+    const ScriptResult result = runCommand(m_updatesCmd, {});
+    QJsonDocument doc = QJsonDocument::fromJson(result.output);
     if (doc.isArray()) {
         for (const QJsonValue& val : doc.array()) {
             if (val.isObject()) {
@@ -141,8 +217,8 @@ QVariantMap ScriptablePlugin::getDetails(const QString& packageId) {
 
     QMap<QString, QString> vars;
     vars[QStringLiteral("ID")] = packageId;
-    QByteArray out = runCommand(m_detailsCmd, vars);
-    QJsonDocument doc = QJsonDocument::fromJson(out);
+    const ScriptResult result = runCommand(m_detailsCmd, vars);
+    QJsonDocument doc = QJsonDocument::fromJson(result.output);
     if (doc.isObject()) {
         QVariantMap parsed = doc.object().toVariantMap();
         for (auto it = parsed.begin(); it != parsed.end(); ++it) {
@@ -159,8 +235,7 @@ bool ScriptablePlugin::install(const QString& packageId, const QVariantMap& opti
     for (auto it = options.begin(); it != options.end(); ++it) {
         vars[it.key().toUpper()] = it.value().toString();
     }
-    runCommand(m_installCmd, vars, progressCb);
-    return true;
+    return runCommand(m_installCmd, vars, progressCb, kOperationTimeoutMs).exitCode == 0;
 }
 
 bool ScriptablePlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
@@ -170,16 +245,14 @@ bool ScriptablePlugin::uninstall(const QString& packageId, const QVariantMap& op
     for (auto it = options.begin(); it != options.end(); ++it) {
         vars[it.key().toUpper()] = it.value().toString();
     }
-    runCommand(m_uninstallCmd, vars, progressCb);
-    return true;
+    return runCommand(m_uninstallCmd, vars, progressCb, kOperationTimeoutMs).exitCode == 0;
 }
 
 bool ScriptablePlugin::launch(const QString& packageId) {
     if (!m_enabled || m_launchCmd.isEmpty()) return false;
     QMap<QString, QString> vars;
     vars[QStringLiteral("ID")] = packageId;
-    runCommand(m_launchCmd, vars);
-    return true;
+    return QProcess::startDetached(QStringLiteral("/bin/sh"), buildShellArguments(m_launchCmd, vars), m_baseDir);
 }
 
 QList<ScriptablePlugin*> ScriptablePlugin::loadFromDirectories(const QStringList& directories, QObject* parent) {

--- a/src/marketplace/plugins/scriptableplugin.hpp
+++ b/src/marketplace/plugins/scriptableplugin.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "packageplugin.hpp"
+#include <QByteArray>
 #include <QJsonObject>
+#include <QMap>
 #include <QSettings>
 
 class ScriptablePlugin : public IPackagePlugin {
@@ -49,5 +51,13 @@ private:
 
     QSettings m_settings{QStringLiteral("AstraMarket"), QStringLiteral("Plugins")};
 
-    QByteArray runCommand(const QString& cmdTemplate, const QMap<QString, QString>& vars, ProgressCallback progressCb = nullptr);
+    struct ScriptResult {
+        int exitCode{-1};
+        QByteArray output;
+        QByteArray error;
+        bool timedOut{false};
+    };
+
+    static QStringList buildShellArguments(const QString& cmdTemplate, const QMap<QString, QString>& vars);
+    ScriptResult runCommand(const QString& cmdTemplate, const QMap<QString, QString>& vars, ProgressCallback progressCb = nullptr, int timeoutMs = 20000);
 };


### PR DESCRIPTION
## Problem

`ScriptablePlugin::runCommand()` substitutes the placeholders textually and then runs the result with `/bin/sh -c`:

```cpp
cmd.replace(QLatin1String("${") + it.key() + QLatin1String("}"), it.value());
proc.start(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), cmd});
```

With the manifest from `PLUGINS.md` (`"search": "./search.sh \"${QUERY}\""`) anything typed into the search bar becomes shell syntax, so a query like

```
vlc"; touch /tmp/pwned; echo "
```

executes `touch` — once per keystroke-debounced search, for every installed plugin. The same applies to `${ID}` and `${SCOPE}` on install/uninstall.

Three more defects in the same function:

- `install()` / `uninstall()` discarded the exit status and returned `true` unconditionally, so a failing script was reported as a successful installation.
- `waitForFinished(10000)` applied to every command, so an installation that takes longer than 10 seconds was killed mid-way — and still reported success because of the point above.
- `requiredBinary` was checked with `QFile::exists(bin) || QFile::exists("/usr/bin/" + bin)`, so a plugin whose helper lives elsewhere in `PATH` (`/usr/local/bin`, `~/.local/bin`) was marked unavailable although the docs promise a `PATH` lookup.

## Change

- Placeholders are rewritten to positional parameters and the values are passed as arguments: `/bin/sh -c './search.sh "${1}"' astra-plugin <query>`. Manifests keep working unchanged, the values are simply no longer parsed as syntax.
- `install`/`uninstall` return `exitCode == 0`; stdout is streamed line by line into the operation log while the command runs, stderr is captured separately so it cannot corrupt the JSON of metadata commands.
- Timeouts by command class: 20s for `search`/`list`/`updates`/`details`, 1h for `install`/`uninstall`, and `launch` is started detached instead of being waited on (a launched application no longer blocks and gets killed).
- `requiredBinary` uses `QStandardPaths::findExecutable()` for plain names, absolute paths keep working.
- `PLUGINS.md` documents the substitution contract, the exit code semantics and the timeouts.

## Testing

Test plugin in `~/.config/astra/plugins/`, with `search.sh` echoing its `$1` back as JSON, comparing 1.1.0 against this branch:

| case | 1.1.0 | this branch |
| --- | --- | --- |
| `astra search 'vlc"; touch /tmp/pwned; echo "' --source Test` | `/tmp/pwned` created | not created, script receives the raw string in `$1` |
| `install.sh` exiting `3` | `✓ Successfully installed`, rc=0 | `✗ Failed to install`, rc=1 |
| `install.sh` sleeping 12s, then touching a marker | killed at 10s, no marker, still reported success | runs to completion, marker written, output streamed |

Normal search/list/details through a plugin manifest keep returning the same results, and `astra sources` still lists the plugin.