### PR TITLE
fix(backends): parse package output in a fixed locale and drop the installed list limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,38 @@ qt_add_resources(astra "qml_resources"
     FILES ${QML_FILES}
 )
 
+option(ASTRA_BUILD_TESTS "Build the AstraMarket unit tests" OFF)
+
+if(ASTRA_BUILD_TESTS)
+    enable_testing()
+    find_package(Qt6 REQUIRED COMPONENTS Test)
+
+    qt_add_executable(tst_parsers
+        tests/tst_parsers.cpp
+        src/marketplace/pluginprocess.cpp
+        src/marketplace/pluginprocess.hpp
+        src/marketplace/plugins/packageplugin.hpp
+        src/marketplace/plugins/pacmanplugin.cpp
+        src/marketplace/plugins/pacmanplugin.hpp
+        src/marketplace/plugins/flatpakplugin.cpp
+        src/marketplace/plugins/flatpakplugin.hpp
+    )
+
+    target_include_directories(tst_parsers PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/marketplace
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/marketplace/plugins
+    )
+
+    target_link_libraries(tst_parsers PRIVATE
+        Qt6::Core
+        Qt6::Network
+        Qt6::Test
+    )
+
+    add_test(NAME parsers COMMAND tst_parsers)
+endif()
+
 # Installation
 include(GNUInstallDirs)
 

--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -1,4 +1,5 @@
 #include "packagemanager.hpp"
+#include "pluginprocess.hpp"
 #include <QFutureWatcher>
 #include <QtConcurrent>
 #include <QDir>
@@ -560,73 +561,19 @@ void PackageManager::updateAllPackages() {
     const bool useCaelestia = useCaelestiaUpdate();
 
     QFuture<bool> future = QtConcurrent::run([this, useCaelestia] {
-        // Flatpak updates
-        if (enableFlatpak() && QFile::exists(QStringLiteral("/usr/bin/flatpak"))) {
+        const auto logLine = [this](const QString& line) { appendLog(line); };
+
+        if (enableFlatpak() && !QStandardPaths::findExecutable(QStringLiteral("flatpak")).isEmpty()) {
             appendLog(QStringLiteral("[%1] Running Flatpak update (flatpak update -y)...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
-            QProcess proc;
-            proc.setProcessChannelMode(QProcess::MergedChannels);
-            proc.start(QStringLiteral("flatpak"), {QStringLiteral("update"), QStringLiteral("-y")});
-            if (proc.waitForStarted(5000)) {
-                while (proc.state() == QProcess::Running) {
-                    if (proc.waitForReadyRead(200)) {
-                        while (proc.canReadLine()) {
-                            QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                            if (!line.isEmpty()) appendLog(line);
-                        }
-                    }
-                }
-                QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-                if (!rest.isEmpty()) {
-                    for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-                        appendLog(line.trimmed());
-                    }
-                }
-            }
+            astra::runProcessStreaming(QStringLiteral("flatpak"), {QStringLiteral("update"), QStringLiteral("-y")}, logLine);
         }
 
-        // System updates: either via Caelestia CLI or direct Pacman
-        if (useCaelestia && QFile::exists(QStringLiteral("/usr/bin/caelestia"))) {
+        if (useCaelestia && !QStandardPaths::findExecutable(QStringLiteral("caelestia")).isEmpty()) {
             appendLog(QStringLiteral("[%1] Running Caelestia update (caelestia update --noconfirm)...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
-            QProcess cProc;
-            cProc.setProcessChannelMode(QProcess::MergedChannels);
-            cProc.start(QStringLiteral("caelestia"), {QStringLiteral("update"), QStringLiteral("--noconfirm")});
-            if (cProc.waitForStarted(5000)) {
-                while (cProc.state() == QProcess::Running) {
-                    if (cProc.waitForReadyRead(200)) {
-                        while (cProc.canReadLine()) {
-                            QString line = QString::fromUtf8(cProc.readLine()).trimmed();
-                            if (!line.isEmpty()) appendLog(line);
-                        }
-                    }
-                }
-                QString rest = QString::fromUtf8(cProc.readAll()).trimmed();
-                if (!rest.isEmpty()) {
-                    for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-                        appendLog(line.trimmed());
-                    }
-                }
-            }
-        } else if (enablePacman() && QFile::exists(QStringLiteral("/usr/bin/pacman"))) {
+            astra::runProcessStreaming(QStringLiteral("caelestia"), {QStringLiteral("update"), QStringLiteral("--noconfirm")}, logLine);
+        } else if (enablePacman() && !QStandardPaths::findExecutable(QStringLiteral("pacman")).isEmpty()) {
             appendLog(QStringLiteral("[%1] Running Pacman update (pkexec pacman -Syu --noconfirm)...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
-            QProcess pacProc;
-            pacProc.setProcessChannelMode(QProcess::MergedChannels);
-            pacProc.start(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm")});
-            if (pacProc.waitForStarted(5000)) {
-                while (pacProc.state() == QProcess::Running) {
-                    if (pacProc.waitForReadyRead(200)) {
-                        while (pacProc.canReadLine()) {
-                            QString line = QString::fromUtf8(pacProc.readLine()).trimmed();
-                            if (!line.isEmpty()) appendLog(line);
-                        }
-                    }
-                }
-                QString rest = QString::fromUtf8(pacProc.readAll()).trimmed();
-                if (!rest.isEmpty()) {
-                    for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-                        appendLog(line.trimmed());
-                    }
-                }
-            }
+            astra::runProcessStreaming(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm")}, logLine);
         }
 
         return true;

--- a/src/marketplace/pluginprocess.cpp
+++ b/src/marketplace/pluginprocess.cpp
@@ -1,0 +1,104 @@
+#include "pluginprocess.hpp"
+
+#include <QElapsedTimer>
+#include <QProcess>
+#include <QProcessEnvironment>
+
+namespace astra {
+
+namespace {
+
+constexpr int kStartTimeoutMs = 5000;
+
+QProcessEnvironment parsableEnvironment() {
+    static const QProcessEnvironment environment = [] {
+        QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+        env.insert(QStringLiteral("LC_ALL"), QStringLiteral("C.UTF-8"));
+        env.insert(QStringLiteral("LANG"), QStringLiteral("C.UTF-8"));
+        env.remove(QStringLiteral("LANGUAGE"));
+        env.remove(QStringLiteral("LC_MESSAGES"));
+        return env;
+    }();
+    return environment;
+}
+
+ProcessResult run(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs, bool mergeChannels) {
+    ProcessResult result;
+
+    QProcess process;
+    process.setProcessEnvironment(parsableEnvironment());
+    if (mergeChannels) process.setProcessChannelMode(QProcess::MergedChannels);
+    process.start(program, arguments);
+
+    if (!process.waitForStarted(kStartTimeoutMs)) {
+        result.error = process.errorString();
+        process.kill();
+        process.waitForFinished(1000);
+        return result;
+    }
+    result.started = true;
+
+    QElapsedTimer elapsed;
+    elapsed.start();
+    QString pending;
+
+    const auto drain = [&](bool flush) {
+        const QString chunk = QString::fromUtf8(process.readAllStandardOutput());
+        if (!chunk.isEmpty()) {
+            result.output += chunk;
+            if (lineCallback) pending += chunk;
+        }
+        if (!mergeChannels) result.error += QString::fromUtf8(process.readAllStandardError());
+
+        if (!lineCallback) return;
+        while (true) {
+            qsizetype breakAt = -1;
+            for (qsizetype i = 0; i < pending.size(); ++i) {
+                const QChar character = pending.at(i);
+                if (character == QLatin1Char('\n') || character == QLatin1Char('\r')) {
+                    breakAt = i;
+                    break;
+                }
+            }
+            if (breakAt < 0) break;
+            const QString line = pending.left(breakAt).trimmed();
+            pending.remove(0, breakAt + 1);
+            if (!line.isEmpty()) lineCallback(line);
+        }
+        if (flush && !pending.isEmpty()) {
+            const QString line = pending.trimmed();
+            pending.clear();
+            if (!line.isEmpty()) lineCallback(line);
+        }
+    };
+
+    while (process.state() == QProcess::Running) {
+        process.waitForReadyRead(200);
+        drain(false);
+
+        if (timeoutMs > 0 && elapsed.hasExpired(timeoutMs)) {
+            result.timedOut = true;
+            process.kill();
+            process.waitForFinished(1000);
+            break;
+        }
+    }
+
+    process.waitForFinished(1000);
+    drain(true);
+
+    if (!result.timedOut) result.exitCode = process.exitCode();
+    return result;
+}
+
+}
+
+ProcessResult runProcess(const QString& program, const QStringList& arguments, int timeoutMs) {
+    return run(program, arguments, nullptr, timeoutMs, false);
+}
+
+ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs) {
+    return run(program, arguments, lineCallback, timeoutMs, true);
+}
+
+}

--- a/src/marketplace/pluginprocess.hpp
+++ b/src/marketplace/pluginprocess.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <functional>
+
+namespace astra {
+
+struct ProcessResult {
+    int exitCode{-1};
+    bool timedOut{false};
+    bool started{false};
+    QString output;
+    QString error;
+
+    bool succeeded() const { return started && !timedOut && exitCode == 0; }
+};
+
+using ProcessLineCallback = std::function<void(const QString& line)>;
+
+ProcessResult runProcess(const QString& program, const QStringList& arguments, int timeoutMs = 15000);
+ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs = 0);
+
+}

--- a/src/marketplace/plugins/aurplugin.cpp
+++ b/src/marketplace/plugins/aurplugin.cpp
@@ -1,7 +1,9 @@
 #include "aurplugin.hpp"
+#include "pluginprocess.hpp"
 #include <QProcess>
 #include <QFile>
 #include <QSet>
+#include <QStandardPaths>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -10,6 +12,12 @@
 #include <QNetworkReply>
 #include <QEventLoop>
 #include <QUrl>
+
+namespace {
+constexpr int kQueryTimeoutMs = 15000;
+constexpr int kUpdatesTimeoutMs = 30000;
+constexpr int kNetworkTimeoutMs = 10000;
+}
 
 AurPlugin::AurPlugin(QObject* parent) : IPackagePlugin(parent) {
     m_enabled = m_settings.value(QStringLiteral("AUR/enabled"), true).toBool();
@@ -22,10 +30,11 @@ bool AurPlugin::isAvailable() const {
 
 QString AurPlugin::resolveHelper() const {
     if (!m_aurHelper.isEmpty() && m_aurHelper != QStringLiteral("auto")) {
-        if (QFile::exists(QStringLiteral("/usr/bin/") + m_aurHelper)) return m_aurHelper;
+        if (!QStandardPaths::findExecutable(m_aurHelper).isEmpty()) return m_aurHelper;
     }
-    if (QFile::exists(QStringLiteral("/usr/bin/paru"))) return QStringLiteral("paru");
-    if (QFile::exists(QStringLiteral("/usr/bin/yay"))) return QStringLiteral("yay");
+    for (const QString& candidate : {QStringLiteral("paru"), QStringLiteral("yay")}) {
+        if (!QStandardPaths::findExecutable(candidate).isEmpty()) return candidate;
+    }
     return QString();
 }
 
@@ -57,6 +66,7 @@ QVariantList AurPlugin::search(const QString& query, const QVariantMap& options)
     QUrl url(QStringLiteral("https://aur.archlinux.org/rpc/v5/search/") + QUrl::toPercentEncoding(q));
     QNetworkRequest req(url);
     req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
+    req.setTransferTimeout(kNetworkTimeoutMs);
 
     QEventLoop loop;
     QNetworkReply* reply = nam.get(req);
@@ -89,31 +99,54 @@ QVariantList AurPlugin::search(const QString& query, const QVariantMap& options)
     return results;
 }
 
+QVariantList AurPlugin::parseForeignOutput(const QString& output) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 2) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = parts.value(0);
+        item[QStringLiteral("name")] = parts.value(0);
+        item[QStringLiteral("version")] = parts.value(1);
+        item[QStringLiteral("backend")] = QStringLiteral("AUR");
+        item[QStringLiteral("repository")] = QStringLiteral("local");
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = parts.value(0);
+        item[QStringLiteral("isInstalled")] = true;
+        results.append(item);
+    }
+    return results;
+}
+
+QVariantList AurPlugin::parseUpdatesOutput(const QString& output) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 4) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = parts.value(0);
+        item[QStringLiteral("name")] = parts.value(0);
+        item[QStringLiteral("version")] = parts.value(1) + QStringLiteral(" -> ") + parts.value(3);
+        item[QStringLiteral("backend")] = QStringLiteral("AUR");
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = parts.value(0);
+        results.append(item);
+    }
+    return results;
+}
+
 QVariantList AurPlugin::getInstalled() {
     QVariantList results;
     if (!m_enabled) return results;
 
-    QProcess qmProc;
-    qmProc.start(QStringLiteral("pacman"), {QStringLiteral("-Qm")});
-    if (qmProc.waitForFinished(3000)) {
-        QString output = QString::fromUtf8(qmProc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& line : lines) {
-            QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (parts.size() >= 2) {
-                QVariantMap item;
-                item[QStringLiteral("id")] = parts.value(0);
-                item[QStringLiteral("name")] = parts.value(0);
-                item[QStringLiteral("version")] = parts.value(1);
-                item[QStringLiteral("backend")] = QStringLiteral("AUR");
-                item[QStringLiteral("repository")] = QStringLiteral("local");
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = parts.value(0);
-                item[QStringLiteral("isInstalled")] = true;
-                results.append(item);
-            }
-        }
-    }
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qm")}, kQueryTimeoutMs);
+    results.append(parseForeignOutput(result.output));
     return results;
 }
 
@@ -124,25 +157,8 @@ QVariantList AurPlugin::getUpdates() {
     QString helper = resolveHelper();
     if (helper.isEmpty()) return results;
 
-    QProcess proc;
-    proc.start(helper, {QStringLiteral("-Qua")});
-    if (proc.waitForFinished(8000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& line : lines) {
-            QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (parts.size() >= 4) {
-                QVariantMap item;
-                item[QStringLiteral("id")] = parts.value(0);
-                item[QStringLiteral("name")] = parts.value(0);
-                item[QStringLiteral("version")] = parts.value(1) + QStringLiteral(" -> ") + parts.value(3);
-                item[QStringLiteral("backend")] = QStringLiteral("AUR");
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = parts.value(0);
-                results.append(item);
-            }
-        }
-    }
+    const astra::ProcessResult result = astra::runProcess(helper, {QStringLiteral("-Qua")}, kUpdatesTimeoutMs);
+    results.append(parseUpdatesOutput(result.output));
     return results;
 }
 
@@ -156,6 +172,7 @@ QVariantMap AurPlugin::getDetails(const QString& packageId) {
     QUrl url(QStringLiteral("https://aur.archlinux.org/rpc/v5/info/") + QUrl::toPercentEncoding(packageId));
     QNetworkRequest req(url);
     req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
+    req.setTransferTimeout(kNetworkTimeoutMs);
 
     QEventLoop loop;
     QNetworkReply* reply = nam.get(req);
@@ -191,50 +208,18 @@ bool AurPlugin::install(const QString& packageId, const QVariantMap& options, Pr
     QString helper = resolveHelper();
     if (helper.isEmpty()) return false;
 
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(helper, {QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId});
-    if (!proc.waitForStarted(5000)) return false;
-
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            while (proc.canReadLine()) {
-                QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                if (!line.isEmpty() && progressCb) progressCb(50, line);
-            }
-        }
-    }
-    QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-    if (!rest.isEmpty() && progressCb) {
-        for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-            progressCb(100, line.trimmed());
-        }
-    }
-    return proc.exitCode() == 0;
+    const astra::ProcessResult result = astra::runProcessStreaming(helper, {QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId}, [&progressCb](const QString& line) {
+        if (progressCb) progressCb(50, line);
+    });
+    return result.succeeded();
 }
 
 bool AurPlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     Q_UNUSED(options);
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Rns"), QStringLiteral("--noconfirm"), packageId});
-    if (!proc.waitForStarted(5000)) return false;
-
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            while (proc.canReadLine()) {
-                QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                if (!line.isEmpty() && progressCb) progressCb(50, line);
-            }
-        }
-    }
-    QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-    if (!rest.isEmpty() && progressCb) {
-        for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-            progressCb(100, line.trimmed());
-        }
-    }
-    return proc.exitCode() == 0;
+    const astra::ProcessResult result = astra::runProcessStreaming(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Rns"), QStringLiteral("--noconfirm"), packageId}, [&progressCb](const QString& line) {
+        if (progressCb) progressCb(50, line);
+    });
+    return result.succeeded();
 }
 
 bool AurPlugin::launch(const QString& packageId) {

--- a/src/marketplace/plugins/aurplugin.hpp
+++ b/src/marketplace/plugins/aurplugin.hpp
@@ -29,6 +29,9 @@ public:
     bool uninstall(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
 
+    static QVariantList parseForeignOutput(const QString& output);
+    static QVariantList parseUpdatesOutput(const QString& output);
+
 private:
     bool m_enabled{true};
     QString m_aurHelper{QStringLiteral("auto")};

--- a/src/marketplace/plugins/flatpakplugin.cpp
+++ b/src/marketplace/plugins/flatpakplugin.cpp
@@ -1,7 +1,10 @@
 #include "flatpakplugin.hpp"
+#include "pluginprocess.hpp"
 #include <QProcess>
 #include <QFile>
+#include <QRegularExpression>
 #include <QSet>
+#include <QStandardPaths>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -16,7 +19,99 @@ FlatpakPlugin::FlatpakPlugin(QObject* parent) : IPackagePlugin(parent) {
 }
 
 bool FlatpakPlugin::isAvailable() const {
-    return QFile::exists(QStringLiteral("/usr/bin/flatpak")) || QFile::exists(QStringLiteral("/bin/flatpak"));
+    return !QStandardPaths::findExecutable(QStringLiteral("flatpak")).isEmpty();
+}
+
+namespace {
+constexpr int kQueryTimeoutMs = 15000;
+constexpr int kSearchTimeoutMs = 5000;
+constexpr int kDetailsTimeoutMs = 10000;
+
+int percentFromLine(const QString& line) {
+    static const QRegularExpression percentPattern(QStringLiteral(R"((\d{1,3})%)"));
+    const QRegularExpressionMatch match = percentPattern.match(line);
+    return match.hasMatch() ? qBound(0, match.captured(1).toInt(), 100) : -1;
+}
+
+QString withoutProgressBar(QString line) {
+    static const QRegularExpression barPattern(QStringLiteral(R"([\x{2588}\x{2591}\x{2593}\x{2592}\-=|]{2,})"));
+    line.remove(barPattern);
+    return line.simplified();
+}
+}
+
+QVariantList FlatpakPlugin::parseSearchOutput(const QString& output, QSet<QString>& seen) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
+        if (parts.size() < 2) continue;
+
+        const QString appId = parts.value(0).trimmed();
+        if (appId.isEmpty() || seen.contains(appId)) continue;
+        seen.insert(appId);
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = appId;
+        item[QStringLiteral("name")] = parts.value(1).trimmed();
+        item[QStringLiteral("summary")] = parts.size() > 2 ? parts.value(2).trimmed() : QString();
+        item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
+        item[QStringLiteral("scope")] = QStringLiteral("user");
+        item[QStringLiteral("icon")] = appId;
+        results.append(item);
+    }
+    return results;
+}
+
+QVariantList FlatpakPlugin::parseInstalledOutput(const QString& output, const QString& scope) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
+        if (parts.size() < 2) continue;
+
+        const QString appId = parts.value(0).trimmed();
+        if (appId.isEmpty()) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = appId;
+        item[QStringLiteral("name")] = parts.value(1).trimmed().isEmpty() ? appId : parts.value(1).trimmed();
+        const QString version = parts.value(2).trimmed();
+        item[QStringLiteral("version")] = version.isEmpty() ? QStringLiteral("latest") : version;
+        item[QStringLiteral("size")] = parts.value(3).trimmed();
+        item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
+        item[QStringLiteral("scope")] = scope;
+        item[QStringLiteral("icon")] = appId;
+        item[QStringLiteral("isInstalled")] = true;
+        results.append(item);
+    }
+    return results;
+}
+
+QVariantList FlatpakPlugin::parseUpdatesOutput(const QString& output) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
+        if (parts.size() < 2) continue;
+
+        const QString appId = parts.value(0).trimmed();
+        if (appId.isEmpty()) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = appId;
+        item[QStringLiteral("name")] = parts.value(1).trimmed().isEmpty() ? appId : parts.value(1).trimmed();
+        const QString version = parts.value(2).trimmed();
+        item[QStringLiteral("version")] = version.isEmpty() ? QStringLiteral("update") : version;
+        item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
+        item[QStringLiteral("scope")] = QStringLiteral("user");
+        item[QStringLiteral("icon")] = appId;
+        results.append(item);
+    }
+    return results;
 }
 
 void FlatpakPlugin::setEnabled(bool enabled) {
@@ -83,7 +178,7 @@ QVariantList FlatpakPlugin::search(const QString& query, const QVariantMap& opti
             QUrl url(QStringLiteral("https://flathub.org/api/v2/collection/category/") + cat);
             QNetworkRequest req(url);
             req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
-            req.setTransferTimeout(2500);
+            req.setTransferTimeout(kSearchTimeoutMs);
 
             QEventLoop loop;
             QNetworkReply* reply = nam.get(req);
@@ -121,7 +216,7 @@ QVariantList FlatpakPlugin::search(const QString& query, const QVariantMap& opti
         QNetworkRequest req(url);
         req.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
         req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
-        req.setTransferTimeout(2500);
+        req.setTransferTimeout(kSearchTimeoutMs);
 
         QJsonObject jsonBody;
         jsonBody[QStringLiteral("query")] = q;
@@ -157,35 +252,12 @@ QVariantList FlatpakPlugin::search(const QString& query, const QVariantMap& opti
         reply->deleteLater();
     }
 
-    // Local CLI flatpak search as fallback / supplemental
     if (results.size() < 10) {
-        QProcess proc;
-        proc.start(QStringLiteral("flatpak"), {QStringLiteral("search"), q.toLower(), QStringLiteral("--columns=app,name,description")});
-        if (proc.waitForFinished(3000)) {
-            QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-            QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-            for (const QString& line : lines) {
-                QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
-                if (parts.size() >= 2) {
-                    QString appId = parts.value(0).trimmed();
-                    QString appName = parts.value(1).trimmed();
-                    if (appId.isEmpty() || seen.contains(appId)) continue;
-                    seen.insert(appId);
-
-                    QVariantMap item;
-                    item[QStringLiteral("id")] = appId;
-                    item[QStringLiteral("name")] = appName;
-                    item[QStringLiteral("summary")] = parts.size() > 2 ? parts.value(2).trimmed() : QStringLiteral("");
-                    item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
-                    item[QStringLiteral("scope")] = QStringLiteral("user");
-                    item[QStringLiteral("icon")] = appId;
-                    results.append(item);
-                }
-            }
-        } else {
-            proc.kill();
-            proc.waitForFinished(300);
-        }
+        const astra::ProcessResult local = astra::runProcess(
+            QStringLiteral("flatpak"),
+            {QStringLiteral("search"), q.toLower(), QStringLiteral("--columns=app,name,description")},
+            kQueryTimeoutMs);
+        results.append(parseSearchOutput(local.output, seen));
     }
     return results;
 }
@@ -194,33 +266,13 @@ QVariantList FlatpakPlugin::getInstalled() {
     QVariantList results;
     if (!isAvailable() || !m_enabled) return results;
 
-    auto fetchScope = [](const QString& scope) -> QVariantList {
-        QVariantList list;
-        QProcess proc;
-        proc.start(QStringLiteral("flatpak"), {QStringLiteral("list"), QStringLiteral("--app"), QStringLiteral("--columns=app,name,version,size"), scope == QStringLiteral("user") ? QStringLiteral("--user") : QStringLiteral("--system")});
-        if (proc.waitForFinished(5000)) {
-            QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-            QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-            for (const QString& line : lines) {
-                QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
-                if (parts.size() >= 2) {
-                    QVariantMap item;
-                    item[QStringLiteral("id")] = parts.value(0).trimmed();
-                    item[QStringLiteral("name")] = parts.value(1).trimmed().isEmpty() ? parts.value(0).trimmed() : parts.value(1).trimmed();
-                    item[QStringLiteral("version")] = parts.size() > 2 ? parts.value(2).trimmed() : QStringLiteral("latest");
-                    item[QStringLiteral("size")] = parts.size() > 3 ? parts.value(3).trimmed() : QStringLiteral("");
-                    item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
-                    item[QStringLiteral("scope")] = scope;
-                    item[QStringLiteral("icon")] = parts.value(0).trimmed();
-                    item[QStringLiteral("isInstalled")] = true;
-                    list.append(item);
-                }
-            }
-        } else {
-            proc.kill();
-            proc.waitForFinished(500);
-        }
-        return list;
+    const auto fetchScope = [](const QString& scope) -> QVariantList {
+        const astra::ProcessResult result = astra::runProcess(
+            QStringLiteral("flatpak"),
+            {QStringLiteral("list"), QStringLiteral("--app"), QStringLiteral("--columns=app,name,version,size"),
+             scope == QStringLiteral("user") ? QStringLiteral("--user") : QStringLiteral("--system")},
+            kQueryTimeoutMs);
+        return parseInstalledOutput(result.output, scope);
     };
 
     results.append(fetchScope(QStringLiteral("user")));
@@ -232,28 +284,11 @@ QVariantList FlatpakPlugin::getUpdates() {
     QVariantList results;
     if (!isAvailable() || !m_enabled) return results;
 
-    QProcess proc;
-    proc.start(QStringLiteral("flatpak"), {QStringLiteral("remote-ls"), QStringLiteral("--updates"), QStringLiteral("--columns=app,name,version")});
-    if (proc.waitForFinished(8000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& line : lines) {
-            QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
-            if (parts.size() >= 2) {
-                QVariantMap item;
-                item[QStringLiteral("id")] = parts.value(0).trimmed();
-                item[QStringLiteral("name")] = parts.value(1).trimmed();
-                item[QStringLiteral("version")] = parts.size() > 2 ? parts.value(2).trimmed() : QStringLiteral("update");
-                item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
-                item[QStringLiteral("scope")] = QStringLiteral("user");
-                item[QStringLiteral("icon")] = parts.value(0).trimmed();
-                results.append(item);
-            }
-        }
-    } else {
-        proc.kill();
-        proc.waitForFinished(500);
-    }
+    const astra::ProcessResult result = astra::runProcess(
+        QStringLiteral("flatpak"),
+        {QStringLiteral("remote-ls"), QStringLiteral("--updates"), QStringLiteral("--columns=app,name,version")},
+        kQueryTimeoutMs);
+    results.append(parseUpdatesOutput(result.output));
     return results;
 }
 
@@ -276,6 +311,7 @@ QVariantMap FlatpakPlugin::getDetails(const QString& packageId) {
     QNetworkRequest req(url);
     req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
     req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    req.setTransferTimeout(kDetailsTimeoutMs);
 
     QEventLoop loop;
     QNetworkReply* reply = nam.get(req);
@@ -330,37 +366,14 @@ bool FlatpakPlugin::install(const QString& packageId, const QVariantMap& options
          << QStringLiteral("-y")
          << packageId;
 
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("flatpak"), args);
-    if (!proc.waitForStarted(5000)) return false;
-
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            QByteArray data = proc.readAll();
-            QString output = QString::fromUtf8(data);
-            QStringList chunks = output.split(QRegularExpression(QStringLiteral("[\r\n]+")), Qt::SkipEmptyParts);
-            for (QString chunk : chunks) {
-                chunk = chunk.trimmed();
-                if (chunk.isEmpty()) continue;
-
-                int pct = 50;
-                QRegularExpression pctRe(QStringLiteral(R"((\d{1,3})%)"));
-                auto match = pctRe.match(chunk);
-                if (match.hasMatch()) {
-                    pct = match.captured(1).toInt();
-                }
-
-                chunk.remove(QRegularExpression(QStringLiteral(R"([█░▓▒\-=|]{2,})")));
-                chunk = chunk.simplified();
-
-                if (progressCb && !chunk.isEmpty()) {
-                    progressCb(pct, chunk);
-                }
-            }
-        }
-    }
-    return proc.exitCode() == 0;
+    const astra::ProcessResult result = astra::runProcessStreaming(QStringLiteral("flatpak"), args, [&progressCb](const QString& line) {
+        if (!progressCb) return;
+        const QString message = withoutProgressBar(line);
+        if (message.isEmpty()) return;
+        const int percent = percentFromLine(line);
+        progressCb(percent < 0 ? 50 : percent, message);
+    });
+    return result.succeeded();
 }
 
 bool FlatpakPlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
@@ -369,37 +382,14 @@ bool FlatpakPlugin::uninstall(const QString& packageId, const QVariantMap& optio
     QStringList args;
     args << QStringLiteral("uninstall") << QStringLiteral("-y") << packageId;
 
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("flatpak"), args);
-    if (!proc.waitForStarted(5000)) return false;
-
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            QByteArray data = proc.readAll();
-            QString output = QString::fromUtf8(data);
-            QStringList chunks = output.split(QRegularExpression(QStringLiteral("[\r\n]+")), Qt::SkipEmptyParts);
-            for (QString chunk : chunks) {
-                chunk = chunk.trimmed();
-                if (chunk.isEmpty()) continue;
-
-                int pct = 50;
-                QRegularExpression pctRe(QStringLiteral(R"((\d{1,3})%)"));
-                auto match = pctRe.match(chunk);
-                if (match.hasMatch()) {
-                    pct = match.captured(1).toInt();
-                }
-
-                chunk.remove(QRegularExpression(QStringLiteral(R"([█░▓▒\-=|]{2,})")));
-                chunk = chunk.simplified();
-
-                if (progressCb && !chunk.isEmpty()) {
-                    progressCb(pct, chunk);
-                }
-            }
-        }
-    }
-    return proc.exitCode() == 0;
+    const astra::ProcessResult result = astra::runProcessStreaming(QStringLiteral("flatpak"), args, [&progressCb](const QString& line) {
+        if (!progressCb) return;
+        const QString message = withoutProgressBar(line);
+        if (message.isEmpty()) return;
+        const int percent = percentFromLine(line);
+        progressCb(percent < 0 ? 50 : percent, message);
+    });
+    return result.succeeded();
 }
 
 bool FlatpakPlugin::launch(const QString& packageId) {

--- a/src/marketplace/plugins/flatpakplugin.hpp
+++ b/src/marketplace/plugins/flatpakplugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "packageplugin.hpp"
+#include <QSet>
 #include <QSettings>
 
 class FlatpakPlugin : public IPackagePlugin {
@@ -27,6 +28,10 @@ public:
     bool launch(const QString& packageId) override;
 
     QList<QVariantMap> getInstallSources(const QString& packageId) override;
+
+    static QVariantList parseSearchOutput(const QString& output, QSet<QString>& seen);
+    static QVariantList parseInstalledOutput(const QString& output, const QString& scope);
+    static QVariantList parseUpdatesOutput(const QString& output);
 
 private:
     bool m_enabled{true};

--- a/src/marketplace/plugins/pacmanplugin.cpp
+++ b/src/marketplace/plugins/pacmanplugin.cpp
@@ -1,15 +1,21 @@
 #include "pacmanplugin.hpp"
-#include <QProcess>
+#include "pluginprocess.hpp"
+
 #include <QFile>
-#include <QSet>
-#include <QDir>
+#include <QProcess>
+#include <QStandardPaths>
+
+namespace {
+constexpr int kQueryTimeoutMs = 15000;
+constexpr int kUpdatesTimeoutMs = 30000;
+}
 
 PacmanPlugin::PacmanPlugin(QObject* parent) : IPackagePlugin(parent) {
     m_enabled = m_settings.value(QStringLiteral("Pacman/enabled"), true).toBool();
 }
 
 bool PacmanPlugin::isAvailable() const {
-    return QFile::exists(QStringLiteral("/usr/bin/pacman"));
+    return !QStandardPaths::findExecutable(QStringLiteral("pacman")).isEmpty();
 }
 
 void PacmanPlugin::setEnabled(bool enabled) {
@@ -20,213 +26,232 @@ void PacmanPlugin::setEnabled(bool enabled) {
     }
 }
 
-QVariantList PacmanPlugin::search(const QString& query, const QVariantMap& options) {
-    Q_UNUSED(options);
+QVariantList PacmanPlugin::parseSearchOutput(const QString& output) {
     QVariantList results;
-    if (!isAvailable() || !m_enabled) return results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    QSet<QString> seen;
 
-    QString q = query.trimmed().toLower();
-    if (q.isEmpty()) return results;
+    for (qsizetype i = 0; i < lines.size(); ++i) {
+        const QString& header = lines.at(i);
+        if (header.startsWith(QLatin1Char(' ')) || header.startsWith(QLatin1Char('\t'))) continue;
 
-    QProcess proc;
-    proc.start(QStringLiteral("pacman"), {QStringLiteral("-Ss"), q});
-    if (proc.waitForFinished(5000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        QSet<QString> seen;
-        for (int i = 0; i < lines.size(); i += 2) {
-            QString header = lines[i];
-            QString desc = (i + 1 < lines.size()) ? lines[i + 1].trimmed() : QStringLiteral("");
-            QStringList parts = header.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (!parts.isEmpty()) {
-                QString fullName = parts.first();
-                QString repo = fullName.contains(QLatin1Char('/')) ? fullName.section(QLatin1Char('/'), 0, 0) : QStringLiteral("extra");
-                QString pkgName = fullName.contains(QLatin1Char('/')) ? fullName.section(QLatin1Char('/'), 1) : fullName;
-
-                if (seen.contains(pkgName)) continue;
-                seen.insert(pkgName);
-
-                QVariantMap item;
-                item[QStringLiteral("id")] = pkgName;
-                item[QStringLiteral("name")] = pkgName;
-                item[QStringLiteral("summary")] = desc;
-                item[QStringLiteral("backend")] = QStringLiteral("Pacman");
-                item[QStringLiteral("repository")] = repo;
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = pkgName;
-                results.append(item);
+        QString description;
+        if (i + 1 < lines.size()) {
+            const QString& next = lines.at(i + 1);
+            if (next.startsWith(QLatin1Char(' ')) || next.startsWith(QLatin1Char('\t'))) {
+                description = next.trimmed();
+                ++i;
             }
         }
-    } else {
-        proc.kill();
-        proc.waitForFinished(500);
+
+        const QString fullName = header.split(QLatin1Char(' '), Qt::SkipEmptyParts).value(0);
+        if (fullName.isEmpty()) continue;
+
+        const QString repository = fullName.contains(QLatin1Char('/')) ? fullName.section(QLatin1Char('/'), 0, 0) : QStringLiteral("extra");
+        const QString packageName = fullName.contains(QLatin1Char('/')) ? fullName.section(QLatin1Char('/'), 1) : fullName;
+        if (packageName.isEmpty() || seen.contains(packageName)) continue;
+        seen.insert(packageName);
+
+        const QStringList headerParts = header.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = packageName;
+        item[QStringLiteral("name")] = packageName;
+        item[QStringLiteral("version")] = headerParts.value(1);
+        item[QStringLiteral("summary")] = description;
+        item[QStringLiteral("backend")] = QStringLiteral("Pacman");
+        item[QStringLiteral("repository")] = repository;
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = packageName;
+        item[QStringLiteral("isInstalled")] = header.contains(QStringLiteral("[installed"));
+        results.append(item);
     }
     return results;
 }
 
-QVariantList PacmanPlugin::getInstalled() {
-    QVariantList results;
-    if (!isAvailable() || !m_enabled) return results;
-
-    QSet<QString> localPkgs;
-    QProcess qmProc;
-    qmProc.start(QStringLiteral("pacman"), {QStringLiteral("-Qm")});
-    if (qmProc.waitForFinished(2000)) {
-        QString qmOut = QString::fromUtf8(qmProc.readAllStandardOutput()).trimmed();
-        QStringList qmLines = qmOut.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& l : qmLines) {
-            QString name = l.split(QLatin1Char(' ')).value(0);
-            if (!name.isEmpty()) localPkgs.insert(name);
-        }
-    } else {
-        qmProc.kill();
-        qmProc.waitForFinished(500);
+QSet<QString> PacmanPlugin::parseForeignOutput(const QString& output) {
+    QSet<QString> packages;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    for (const QString& line : lines) {
+        const QString name = line.split(QLatin1Char(' '), Qt::SkipEmptyParts).value(0);
+        if (!name.isEmpty()) packages.insert(name);
     }
+    return packages;
+}
 
-    QProcess proc;
-    proc.start(QStringLiteral("pacman"), {QStringLiteral("-Qe")});
-    if (proc.waitForFinished(5000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        int count = 0;
-        for (const QString& line : lines) {
-            if (++count > 200) break;
-            QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (parts.size() >= 2) {
-                QString pkgId = parts.value(0);
-                if (localPkgs.contains(pkgId)) continue;
+QVariantList PacmanPlugin::parseInstalledOutput(const QString& output, const QSet<QString>& foreign) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
 
-                QVariantMap item;
-                item[QStringLiteral("id")] = pkgId;
-                item[QStringLiteral("name")] = pkgId;
-                item[QStringLiteral("version")] = parts.value(1);
-                item[QStringLiteral("backend")] = QStringLiteral("Pacman");
-                item[QStringLiteral("repository")] = QStringLiteral("extra");
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = pkgId;
-                item[QStringLiteral("isInstalled")] = true;
-                results.append(item);
-            }
-        }
-    } else {
-        proc.kill();
-        proc.waitForFinished(500);
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 2) continue;
+
+        const QString packageId = parts.value(0);
+        if (foreign.contains(packageId)) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = packageId;
+        item[QStringLiteral("name")] = packageId;
+        item[QStringLiteral("version")] = parts.value(1);
+        item[QStringLiteral("backend")] = QStringLiteral("Pacman");
+        item[QStringLiteral("repository")] = QStringLiteral("extra");
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = packageId;
+        item[QStringLiteral("isInstalled")] = true;
+        results.append(item);
     }
     return results;
 }
 
-QVariantList PacmanPlugin::getUpdates() {
+QVariantList PacmanPlugin::parseUpdatesOutput(const QString& output) {
     QVariantList results;
-    if (!isAvailable() || !m_enabled) return results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
 
-    QProcess proc;
-    proc.start(QStringLiteral("checkupdates"));
-    if (proc.waitForFinished(8000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& line : lines) {
-            QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (parts.size() >= 4) {
-                QVariantMap item;
-                item[QStringLiteral("id")] = parts.value(0);
-                item[QStringLiteral("name")] = parts.value(0);
-                item[QStringLiteral("version")] = parts.value(1) + QStringLiteral(" -> ") + parts.value(3);
-                item[QStringLiteral("backend")] = QStringLiteral("Pacman");
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = parts.value(0);
-                results.append(item);
-            }
-        }
-    } else {
-        proc.kill();
-        proc.waitForFinished(500);
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 4) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = parts.value(0);
+        item[QStringLiteral("name")] = parts.value(0);
+        item[QStringLiteral("version")] = parts.value(1) + QStringLiteral(" -> ") + parts.value(3);
+        item[QStringLiteral("backend")] = QStringLiteral("Pacman");
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = parts.value(0);
+        results.append(item);
     }
     return results;
 }
 
-QVariantMap PacmanPlugin::getDetails(const QString& packageId) {
+QVariantMap PacmanPlugin::parseInfoOutput(const QString& output, const QString& packageId) {
     QVariantMap map;
     map[QStringLiteral("id")] = packageId;
     map[QStringLiteral("name")] = packageId;
     map[QStringLiteral("backend")] = QStringLiteral("Pacman");
 
-    QProcess proc;
-    proc.start(QStringLiteral("pacman"), {QStringLiteral("-Si"), packageId});
-    if (!proc.waitForFinished(3000) || proc.exitCode() != 0) {
-        proc.start(QStringLiteral("pacman"), {QStringLiteral("-Qi"), packageId});
-        proc.waitForFinished(3000);
-    }
+    QMap<QString, QString> fields;
+    QString currentField;
 
-    QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-    QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    const QStringList lines = output.split(QLatin1Char('\n'));
     for (const QString& line : lines) {
-        if (line.startsWith(QLatin1String("Description"))) {
-            map[QStringLiteral("summary")] = line.section(QLatin1Char(':'), 1).trimmed();
-            map[QStringLiteral("description")] = line.section(QLatin1Char(':'), 1).trimmed();
-        } else if (line.startsWith(QLatin1String("Version"))) {
-            map[QStringLiteral("version")] = line.section(QLatin1Char(':'), 1).trimmed();
-        } else if (line.startsWith(QLatin1String("URL"))) {
-            map[QStringLiteral("homepage")] = line.section(QLatin1Char(':'), 1).trimmed();
-        } else if (line.startsWith(QLatin1String("Licenses"))) {
-            map[QStringLiteral("license")] = line.section(QLatin1Char(':'), 1).trimmed();
-        } else if (line.startsWith(QLatin1String("Packager"))) {
-            map[QStringLiteral("developer")] = line.section(QLatin1Char(':'), 1).trimmed();
+        if (line.trimmed().isEmpty()) continue;
+
+        const qsizetype separator = line.indexOf(QLatin1String(" : "));
+        const bool continuation = line.startsWith(QLatin1Char(' ')) || line.startsWith(QLatin1Char('\t'));
+
+        if (!continuation && separator > 0) {
+            currentField = line.left(separator).trimmed();
+            fields.insert(currentField, line.mid(separator + 3).trimmed());
+        } else if (!currentField.isEmpty()) {
+            fields[currentField] += QLatin1Char(' ') + line.trimmed();
         }
     }
+
+    const auto assign = [&](const QString& field, const QString& key) {
+        const QString value = fields.value(field);
+        if (!value.isEmpty() && value != QLatin1String("None")) map[key] = value;
+    };
+
+    assign(QStringLiteral("Description"), QStringLiteral("summary"));
+    assign(QStringLiteral("Description"), QStringLiteral("description"));
+    assign(QStringLiteral("Version"), QStringLiteral("version"));
+    assign(QStringLiteral("URL"), QStringLiteral("homepage"));
+    assign(QStringLiteral("Licenses"), QStringLiteral("license"));
+    assign(QStringLiteral("Packager"), QStringLiteral("developer"));
+    assign(QStringLiteral("Repository"), QStringLiteral("repository"));
+    assign(QStringLiteral("Installed Size"), QStringLiteral("size"));
+    assign(QStringLiteral("Download Size"), QStringLiteral("downloadSize"));
+
     return map;
+}
+
+QVariantList PacmanPlugin::search(const QString& query, const QVariantMap& options) {
+    Q_UNUSED(options);
+    if (!isAvailable() || !m_enabled) return {};
+
+    const QString trimmed = query.trimmed();
+    if (trimmed.isEmpty()) return {};
+
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Ss"), trimmed.toLower()}, kQueryTimeoutMs);
+    return parseSearchOutput(result.output);
+}
+
+QVariantList PacmanPlugin::getInstalled() {
+    if (!isAvailable() || !m_enabled) return {};
+
+    const astra::ProcessResult foreign = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qm")}, kQueryTimeoutMs);
+    const astra::ProcessResult explicitly = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qe")}, kQueryTimeoutMs);
+    return parseInstalledOutput(explicitly.output, parseForeignOutput(foreign.output));
+}
+
+QVariantList PacmanPlugin::getUpdates() {
+    if (!isAvailable() || !m_enabled) return {};
+    if (QStandardPaths::findExecutable(QStringLiteral("checkupdates")).isEmpty()) return {};
+
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("checkupdates"), {}, kUpdatesTimeoutMs);
+    return parseUpdatesOutput(result.output);
+}
+
+QVariantMap PacmanPlugin::getDetails(const QString& packageId) {
+    astra::ProcessResult result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Si"), packageId}, kQueryTimeoutMs);
+    if (!result.succeeded() || result.output.trimmed().isEmpty()) {
+        result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qi"), packageId}, kQueryTimeoutMs);
+    }
+    return parseInfoOutput(result.output, packageId);
 }
 
 bool PacmanPlugin::install(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     Q_UNUSED(options);
     if (!isAvailable()) return false;
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId});
-    if (!proc.waitForStarted(5000)) return false;
 
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            while (proc.canReadLine()) {
-                QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                if (!line.isEmpty() && progressCb) progressCb(50, line);
-            }
-        }
+    const astra::ProcessResult result = astra::runProcessStreaming(
+        QStringLiteral("pkexec"),
+        {QStringLiteral("pacman"), QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId},
+        [&progressCb](const QString& line) {
+            if (progressCb) progressCb(50, line);
+        });
+
+    if (progressCb && !result.succeeded() && !result.started) {
+        progressCb(0, QStringLiteral("Could not start pkexec"));
     }
-    QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-    if (!rest.isEmpty() && progressCb) {
-        for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-            progressCb(100, line.trimmed());
-        }
-    }
-    return proc.exitCode() == 0;
+    return result.succeeded();
 }
 
 bool PacmanPlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     Q_UNUSED(options);
     if (!isAvailable()) return false;
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Rns"), QStringLiteral("--noconfirm"), packageId});
-    if (!proc.waitForStarted(5000)) return false;
 
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            while (proc.canReadLine()) {
-                QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                if (!line.isEmpty() && progressCb) progressCb(50, line);
-            }
-        }
+    const astra::ProcessResult result = astra::runProcessStreaming(
+        QStringLiteral("pkexec"),
+        {QStringLiteral("pacman"), QStringLiteral("-Rns"), QStringLiteral("--noconfirm"), packageId},
+        [&progressCb](const QString& line) {
+            if (progressCb) progressCb(50, line);
+        });
+
+    if (progressCb && !result.succeeded() && !result.started) {
+        progressCb(0, QStringLiteral("Could not start pkexec"));
     }
-    QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-    if (!rest.isEmpty() && progressCb) {
-        for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-            progressCb(100, line.trimmed());
-        }
-    }
-    return proc.exitCode() == 0;
+    return result.succeeded();
 }
 
 bool PacmanPlugin::launch(const QString& packageId) {
     if (!isAvailable()) return false;
+
+    const astra::ProcessResult files = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qlq"), packageId}, kQueryTimeoutMs);
+    const QStringList lines = files.output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    QString fallback;
+    for (const QString& line : lines) {
+        const QString path = line.trimmed();
+        if (!path.startsWith(QLatin1String("/usr/bin/")) || path.endsWith(QLatin1Char('/'))) continue;
+
+        const QString binary = path.mid(9);
+        if (binary.isEmpty()) continue;
+        if (binary.compare(packageId, Qt::CaseInsensitive) == 0) return QProcess::startDetached(path);
+        if (fallback.isEmpty()) fallback = path;
+    }
+
+    if (!fallback.isEmpty()) return QProcess::startDetached(fallback);
     return QProcess::startDetached(packageId);
 }

--- a/src/marketplace/plugins/pacmanplugin.hpp
+++ b/src/marketplace/plugins/pacmanplugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "packageplugin.hpp"
+#include <QSet>
 #include <QSettings>
 
 class PacmanPlugin : public IPackagePlugin {
@@ -25,6 +26,12 @@ public:
     bool install(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool uninstall(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
+
+    static QVariantList parseSearchOutput(const QString& output);
+    static QSet<QString> parseForeignOutput(const QString& output);
+    static QVariantList parseInstalledOutput(const QString& output, const QSet<QString>& foreign);
+    static QVariantList parseUpdatesOutput(const QString& output);
+    static QVariantMap parseInfoOutput(const QString& output, const QString& packageId);
 
 private:
     bool m_enabled{true};

--- a/tests/tst_parsers.cpp
+++ b/tests/tst_parsers.cpp
@@ -1,0 +1,191 @@
+#include <QTest>
+#include <QElapsedTimer>
+#include <QSet>
+
+#include "pluginprocess.hpp"
+#include "flatpakplugin.hpp"
+#include "pacmanplugin.hpp"
+
+class TestParsers : public QObject {
+    Q_OBJECT
+
+private slots:
+    void pacmanSearchOutputIsParsed();
+    void pacmanSearchKeepsEveryEntry();
+    void pacmanInstalledSkipsForeignPackages();
+    void pacmanInstalledIsNotTruncated();
+    void pacmanUpdatesAreParsed();
+    void pacmanInfoParsesWrappedFields();
+    void pacmanInfoIgnoresEmptyValues();
+    void flatpakInstalledUsesColumns();
+    void flatpakInstalledFallsBackToAppId();
+    void flatpakUpdatesAreParsed();
+    void processReportsExitCode();
+    void processRunsWithParsableLocale();
+    void processStopsAtTimeout();
+    void processStreamsLinesSplitByCarriageReturn();
+};
+
+void TestParsers::pacmanSearchOutputIsParsed() {
+    const QString output = QStringLiteral(
+        "extra/vlc 3.0.21-10 [installed]\n"
+        "    Free and open source cross-platform multimedia player\n"
+        "multilib/lib32-vlc 3.0.21-1\n"
+        "    32-bit libraries\n");
+
+    const QVariantList results = PacmanPlugin::parseSearchOutput(output);
+    QCOMPARE(results.size(), 2);
+
+    const QVariantMap first = results.first().toMap();
+    QCOMPARE(first.value(QStringLiteral("id")).toString(), QStringLiteral("vlc"));
+    QCOMPARE(first.value(QStringLiteral("version")).toString(), QStringLiteral("3.0.21-10"));
+    QCOMPARE(first.value(QStringLiteral("repository")).toString(), QStringLiteral("extra"));
+    QCOMPARE(first.value(QStringLiteral("summary")).toString(), QStringLiteral("Free and open source cross-platform multimedia player"));
+    QVERIFY(first.value(QStringLiteral("isInstalled")).toBool());
+
+    const QVariantMap second = results.last().toMap();
+    QCOMPARE(second.value(QStringLiteral("id")).toString(), QStringLiteral("lib32-vlc"));
+    QCOMPARE(second.value(QStringLiteral("repository")).toString(), QStringLiteral("multilib"));
+    QVERIFY(!second.value(QStringLiteral("isInstalled")).toBool());
+}
+
+void TestParsers::pacmanSearchKeepsEveryEntry() {
+    QString output;
+    for (int i = 0; i < 400; ++i) {
+        output += QStringLiteral("extra/package-%1 1.0-1\n    summary %1\n").arg(i);
+    }
+    QCOMPARE(PacmanPlugin::parseSearchOutput(output).size(), 400);
+}
+
+void TestParsers::pacmanInstalledSkipsForeignPackages() {
+    const QString output = QStringLiteral("bash 5.3.15-1\nastramarket-git 1.1.0.r0-1\nvlc 3.0.21-10\n");
+    const QSet<QString> foreign = PacmanPlugin::parseForeignOutput(QStringLiteral("astramarket-git 1.1.0.r0-1\n"));
+
+    const QVariantList results = PacmanPlugin::parseInstalledOutput(output, foreign);
+    QCOMPARE(results.size(), 2);
+    QCOMPARE(results.first().toMap().value(QStringLiteral("id")).toString(), QStringLiteral("bash"));
+    QCOMPARE(results.first().toMap().value(QStringLiteral("version")).toString(), QStringLiteral("5.3.15-1"));
+    QVERIFY(results.first().toMap().value(QStringLiteral("isInstalled")).toBool());
+}
+
+void TestParsers::pacmanInstalledIsNotTruncated() {
+    QString output;
+    for (int i = 0; i < 512; ++i) {
+        output += QStringLiteral("package-%1 1.0-1\n").arg(i);
+    }
+    QCOMPARE(PacmanPlugin::parseInstalledOutput(output, {}).size(), 512);
+}
+
+void TestParsers::pacmanUpdatesAreParsed() {
+    const QString output = QStringLiteral("linux 7.1.7.arch1-1 -> 7.1.8.arch1-3\nvlc 3.0.21-9 -> 3.0.21-10\n");
+
+    const QVariantList results = PacmanPlugin::parseUpdatesOutput(output);
+    QCOMPARE(results.size(), 2);
+    QCOMPARE(results.first().toMap().value(QStringLiteral("id")).toString(), QStringLiteral("linux"));
+    QCOMPARE(results.first().toMap().value(QStringLiteral("version")).toString(), QStringLiteral("7.1.7.arch1-1 -> 7.1.8.arch1-3"));
+}
+
+void TestParsers::pacmanInfoParsesWrappedFields() {
+    const QString output = QStringLiteral(
+        "Repository      : core\n"
+        "Name            : linux\n"
+        "Version         : 7.1.8.arch1-3\n"
+        "Description     : The Linux kernel\n"
+        "URL             : https://github.com/archlinux/linux\n"
+        "Licenses        : GPL-2.0-only\n"
+        "Optional Deps   : linux-headers: headers and scripts\n"
+        "                  linux-firmware: firmware images\n"
+        "Installed Size  : 147.72 MiB\n"
+        "Packager        : Frederik Schwan <freswa@archlinux.org>\n");
+
+    const QVariantMap details = PacmanPlugin::parseInfoOutput(output, QStringLiteral("linux"));
+    QCOMPARE(details.value(QStringLiteral("version")).toString(), QStringLiteral("7.1.8.arch1-3"));
+    QCOMPARE(details.value(QStringLiteral("summary")).toString(), QStringLiteral("The Linux kernel"));
+    QCOMPARE(details.value(QStringLiteral("homepage")).toString(), QStringLiteral("https://github.com/archlinux/linux"));
+    QCOMPARE(details.value(QStringLiteral("license")).toString(), QStringLiteral("GPL-2.0-only"));
+    QCOMPARE(details.value(QStringLiteral("developer")).toString(), QStringLiteral("Frederik Schwan <freswa@archlinux.org>"));
+    QCOMPARE(details.value(QStringLiteral("repository")).toString(), QStringLiteral("core"));
+    QCOMPARE(details.value(QStringLiteral("size")).toString(), QStringLiteral("147.72 MiB"));
+}
+
+void TestParsers::pacmanInfoIgnoresEmptyValues() {
+    const QString output = QStringLiteral(
+        "Name            : bash\n"
+        "Version         : 5.3.15-1\n"
+        "Groups          : None\n"
+        "URL             : None\n");
+
+    const QVariantMap details = PacmanPlugin::parseInfoOutput(output, QStringLiteral("bash"));
+    QVERIFY(!details.contains(QStringLiteral("homepage")));
+    QCOMPARE(details.value(QStringLiteral("name")).toString(), QStringLiteral("bash"));
+}
+
+void TestParsers::flatpakInstalledUsesColumns() {
+    const QString output = QStringLiteral("org.videolan.VLC\tVLC\t3.0.21\t312.4 MB\ncom.spotify.Client\tSpotify\t1.2.52\t280.0 MB\n");
+
+    const QVariantList results = FlatpakPlugin::parseInstalledOutput(output, QStringLiteral("system"));
+    QCOMPARE(results.size(), 2);
+
+    const QVariantMap first = results.first().toMap();
+    QCOMPARE(first.value(QStringLiteral("id")).toString(), QStringLiteral("org.videolan.VLC"));
+    QCOMPARE(first.value(QStringLiteral("name")).toString(), QStringLiteral("VLC"));
+    QCOMPARE(first.value(QStringLiteral("version")).toString(), QStringLiteral("3.0.21"));
+    QCOMPARE(first.value(QStringLiteral("size")).toString(), QStringLiteral("312.4 MB"));
+    QCOMPARE(first.value(QStringLiteral("scope")).toString(), QStringLiteral("system"));
+}
+
+void TestParsers::flatpakInstalledFallsBackToAppId() {
+    const QVariantList results = FlatpakPlugin::parseInstalledOutput(QStringLiteral("org.gnome.Platform\t\t\t\n"), QStringLiteral("user"));
+    QCOMPARE(results.size(), 1);
+    QCOMPARE(results.first().toMap().value(QStringLiteral("name")).toString(), QStringLiteral("org.gnome.Platform"));
+    QCOMPARE(results.first().toMap().value(QStringLiteral("version")).toString(), QStringLiteral("latest"));
+}
+
+void TestParsers::flatpakUpdatesAreParsed() {
+    const QVariantList results = FlatpakPlugin::parseUpdatesOutput(QStringLiteral("org.freedesktop.Platform.GL.default\tMesa\t26.1.5\n"));
+    QCOMPARE(results.size(), 1);
+    QCOMPARE(results.first().toMap().value(QStringLiteral("name")).toString(), QStringLiteral("Mesa"));
+    QCOMPARE(results.first().toMap().value(QStringLiteral("backend")).toString(), QStringLiteral("Flatpak"));
+}
+
+void TestParsers::processReportsExitCode() {
+    const astra::ProcessResult ok = astra::runProcess(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), QStringLiteral("printf hello")});
+    QVERIFY(ok.succeeded());
+    QCOMPARE(ok.output, QStringLiteral("hello"));
+
+    const astra::ProcessResult failed = astra::runProcess(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), QStringLiteral("exit 3")});
+    QVERIFY(!failed.succeeded());
+    QCOMPARE(failed.exitCode, 3);
+
+    const astra::ProcessResult missing = astra::runProcess(QStringLiteral("astra-does-not-exist"), {});
+    QVERIFY(!missing.started);
+    QVERIFY(!missing.succeeded());
+}
+
+void TestParsers::processRunsWithParsableLocale() {
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), QStringLiteral("printf '%s' \"$LC_ALL\"")});
+    QCOMPARE(result.output, QStringLiteral("C.UTF-8"));
+}
+
+void TestParsers::processStopsAtTimeout() {
+    QElapsedTimer timer;
+    timer.start();
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), QStringLiteral("sleep 10")}, 500);
+    QVERIFY(result.timedOut);
+    QVERIFY(!result.succeeded());
+    QVERIFY(timer.elapsed() < 5000);
+}
+
+void TestParsers::processStreamsLinesSplitByCarriageReturn() {
+    QStringList lines;
+    const astra::ProcessResult result = astra::runProcessStreaming(
+        QStringLiteral("/bin/sh"),
+        {QStringLiteral("-c"), QStringLiteral("printf 'first\\rsecond\\nthird'")},
+        [&lines](const QString& line) { lines.append(line); });
+
+    QVERIFY(result.succeeded());
+    QCOMPARE(lines, QStringList({QStringLiteral("first"), QStringLiteral("second"), QStringLiteral("third")}));
+}
+
+QTEST_GUILESS_MAIN(TestParsers)
+#include "tst_parsers.moc"


### PR DESCRIPTION
## Problems

**1. Package output is parsed in the user's locale.** Every backend command inherits the session locale, and `PacmanPlugin::getDetails()` matches on English field names (`Description`, `Licenses`, `Packager`). On a German system pacman prints:

```
Beschreibung    : The GNU Bourne Again shell
Lizenzen        : GPL-3.0-or-later
Paketierer      : Tobias Powalowski <tpowa@archlinux.org>
```

so the detail page and `astra info` show only the two fields whose names happen to be identical in both languages:

```
$ LC_ALL=de_DE.UTF-8 astra info bash --source Pacman
ID:          bash
Backend:     Pacman
Version:     5.3.15-1
Homepage:    https://www.gnu.org/software/bash/bash.html
```

**2. The installed list is cut off after 200 lines.** `getInstalled()` breaks out of the `pacman -Qe` loop at 200 — and counts foreign packages towards that limit before filtering them out. On this machine 263 native packages are installed and 187 were listed.

**3. No timeouts, no error signal.** The AUR RPC calls and the Flathub appstream request run a `QEventLoop` without `setTransferTimeout()`, so a stalled connection blocks a worker thread indefinitely. Process calls used `waitForFinished(n)` and then read whatever was there, with no way to distinguish "empty result" from "program missing" or "timed out".

## Change

New `src/marketplace/pluginprocess.{hpp,cpp}`: one place that runs backend commands with `LC_ALL=C.UTF-8` / `LANG=C.UTF-8`, applies a timeout, streams merged output line by line (splitting on `\r` as well, which is what the flatpak and pacman progress output uses) and reports `started` / `timedOut` / `exitCode` separately. Pacman, AUR, Flatpak and the "update all" path in `PackageManager` use it, which removes four copies of the same blocking read loop.

Further fixes in the touched code:

- `pacman -Qe` is no longer truncated.
- `pacman -Si` continuation lines (wrapped `Optional Deps`, long descriptions) are appended to their field instead of being dropped, `None` placeholders are no longer stored as values, and `Repository` / `Installed Size` / `Download Size` are exposed.
- `PacmanPlugin::launch()` resolved a binary by package name (`QProcess::startDetached(packageId)`), which fails for every package whose executable is not named after it. It now resolves `/usr/bin/*` from `pacman -Qlq`, preferring an exact name match.
- Missing transfer timeouts added (AUR search/info, Flathub appstream).
- `isAvailable()` and the AUR helper lookup use `QStandardPaths::findExecutable()` instead of hardcoded `/usr/bin` checks, so helpers in `/usr/local/bin` or `~/.local/bin` are found.
- `getUpdates()` returns early when `checkupdates` (pacman-contrib) is not installed instead of waiting for a process that cannot start.
- Empty flatpak version columns fall back to `latest`/`update` as intended.

## Tests

New `tests/tst_parsers.cpp` (Qt Test), enabled with `-DASTRA_BUILD_TESTS=ON` and registered with ctest — 16 cases covering the pacman search/installed/updates/info parsers (including wrapped fields and the missing truncation), the flatpak column parsers, and the process helper (exit code, missing program, forced locale, timeout, `\r`-separated streaming).

```
$ cmake -B build -G Ninja -DASTRA_BUILD_TESTS=ON && cmake --build build && ctest --test-dir build
100% tests passed, 0 tests failed out of 1
Totals: 16 passed, 0 failed
```

Manual verification on Arch (Qt 6.11.2):

| check | before | after |
| --- | --- | --- |
| `LC_ALL=de_DE.UTF-8 astra info bash --source Pacman` | version + homepage | version, developer, license, summary, description, homepage |
| `astra list \| grep -c Pacman` | 187 | 263 (matches `pacman -Qe` minus `pacman -Qm`) |
| `astra search vlc`, `astra update`, flatpak installed list | unchanged | unchanged |

GUI (`--gui`) starts and renders unchanged.