### PR TITLE
fix(appimage): install, launch and remove agree on one location

### DIFF
--- a/qml/qs/modules/astra/pages/AppImagePage.qml
+++ b/qml/qs/modules/astra/pages/AppImagePage.qml
@@ -206,7 +206,7 @@ PageBase {
                         inactiveOnColour: Colours.palette.m3error
                         activeOnColour: Colours.palette.m3error
                         onClicked: {
-                            AppImageInstaller.uninstallAppImage(modelData.name);
+                            AppImageInstaller.uninstallAppImage(modelData.desktopPath || modelData.path || modelData.name);
                             root.reloadAppImages();
                         }
                     }
@@ -216,7 +216,7 @@ PageBase {
                         icon: "open_in_new"
                         type: IconButton.Tonal
                         onClicked: {
-                            AppImageInstaller.launchAppImage(modelData.name);
+                            AppImageInstaller.launchAppImage(modelData.desktopPath || modelData.path || modelData.name);
                         }
                     }
                 }

--- a/src/marketplace/appimageinstaller.cpp
+++ b/src/marketplace/appimageinstaller.cpp
@@ -3,12 +3,65 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QDir>
+#include <QSet>
 #include <QUrl>
 #include <QStandardPaths>
 #include <QDebug>
 #include <QRegularExpression>
 #include <QTemporaryDir>
 #include <QTextStream>
+
+namespace {
+
+QString applicationsDirectory() {
+    return QDir::homePath() + QStringLiteral("/.local/share/applications");
+}
+
+QString binaryDirectory() {
+    return QDir::homePath() + QStringLiteral("/.local/bin");
+}
+
+QString iconDirectory() {
+    return QDir::homePath() + QStringLiteral("/.local/share/icons/hicolor/512x512/apps");
+}
+
+QString portableDirectory() {
+    return QDir::homePath() + QStringLiteral("/Applications");
+}
+
+QString slugify(const QString& value) {
+    static const QRegularExpression unsupported(QStringLiteral("[^a-z0-9_-]"));
+    QString slug = value.toLower();
+    slug.replace(unsupported, QStringLiteral("-"));
+    return slug;
+}
+
+QString resolveIcon(const QString& icon) {
+    if (icon.isEmpty()) return QString();
+    if (icon.startsWith(QLatin1Char('/'))) return QFile::exists(icon) ? icon : QString();
+
+    const QString base = iconDirectory() + QStringLiteral("/") + icon;
+    for (const QString& candidate : {base, base + QStringLiteral(".png"), base + QStringLiteral(".svg")}) {
+        if (QFile::exists(candidate)) return candidate;
+    }
+    return icon;
+}
+
+QString executableFromExecLine(QString exec) {
+    exec.remove(QLatin1Char('"'));
+    exec.remove(QStringLiteral(" %U"));
+    exec.remove(QStringLiteral(" %u"));
+    exec.remove(QStringLiteral(" %F"));
+    exec.remove(QStringLiteral(" %f"));
+    return exec.trimmed();
+}
+
+QString humanSize(qint64 bytes) {
+    if (bytes <= 0) return QString();
+    return QString::number(bytes / (1024.0 * 1024.0), 'f', 1) + QStringLiteral(" MB");
+}
+
+}
 
 AppImageInstaller::AppImageInstaller(QObject* parent)
     : QObject(parent) {}
@@ -39,12 +92,11 @@ bool AppImageInstaller::installAppImage(const QString& fileUrlOrPath) {
 
     QString appBaseName = fileInfo.completeBaseName();
 
-    QString safeAppName = appBaseName.toLower();
-    safeAppName.replace(QRegularExpression(QStringLiteral("[^a-z0-9_-]")), QStringLiteral("-"));
+    const QString safeAppName = slugify(appBaseName);
 
     setStatus(true, QStringLiteral("Installing ") + appBaseName + QStringLiteral("..."));
 
-    QString binDir = QDir::homePath() + QStringLiteral("/.local/bin");
+    const QString binDir = binaryDirectory();
     QDir().mkpath(binDir);
 
     QString destAppImagePath = binDir + QStringLiteral("/") + safeAppName + QStringLiteral(".AppImage");
@@ -98,7 +150,7 @@ bool AppImageInstaller::installAppImage(const QString& fileUrlOrPath) {
 
     QString desktopPath = generateDesktopFile(safeAppName, destAppImagePath, iconPath, displayName);
 
-    QProcess::startDetached(QStringLiteral("update-desktop-database"), {QDir::homePath() + QStringLiteral("/.local/share/applications")});
+    QProcess::startDetached(QStringLiteral("update-desktop-database"), {applicationsDirectory()});
 
     if (QFile::exists(QStringLiteral("/usr/bin/notify-send")) || QFile::exists(QStringLiteral("/bin/notify-send"))) {
         QString notifIcon = iconPath.isEmpty() ? QStringLiteral("system-software-install") : iconPath;
@@ -116,7 +168,7 @@ bool AppImageInstaller::installAppImage(const QString& fileUrlOrPath) {
 
 QString AppImageInstaller::extractIcon(const QString& tempExtractDir, const QString& appName) {
     QDir extractDir(tempExtractDir);
-    QString iconsDestDir = QDir::homePath() + QStringLiteral("/.local/share/icons/hicolor/512x512/apps");
+    const QString iconsDestDir = iconDirectory();
     QDir().mkpath(iconsDestDir);
 
     QStringList iconFilters;
@@ -152,7 +204,7 @@ QString AppImageInstaller::extractIcon(const QString& tempExtractDir, const QStr
 }
 
 QString AppImageInstaller::generateDesktopFile(const QString& appName, const QString& execPath, const QString& iconPath, const QString& displayName) {
-    QString appsDir = QDir::homePath() + QStringLiteral("/.local/share/applications");
+    const QString appsDir = applicationsDirectory();
     QDir().mkpath(appsDir);
 
     QString desktopPath = appsDir + QStringLiteral("/appimage-") + appName + QStringLiteral(".desktop");
@@ -175,82 +227,130 @@ QString AppImageInstaller::generateDesktopFile(const QString& appName, const QSt
     return desktopPath;
 }
 
+QVariantList AppImageInstaller::installedAppImages() {
+    QVariantList entries;
+    QSet<QString> seenPaths;
+
+    QDir applications(applicationsDirectory());
+    const QStringList desktopFiles = applications.entryList({QStringLiteral("appimage-*.desktop")}, QDir::Files, QDir::Name);
+    for (const QString& fileName : desktopFiles) {
+        QFile file(applications.filePath(fileName));
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) continue;
+
+        QString identifier = fileName.mid(9);
+        if (identifier.endsWith(QLatin1String(".desktop"))) identifier.chop(8);
+
+        QString name;
+        QString exec;
+        QString icon;
+        QString comment;
+
+        QTextStream stream(&file);
+        while (!stream.atEnd()) {
+            const QString line = stream.readLine().trimmed();
+            if (line.startsWith(QLatin1String("Name="))) name = line.mid(5).trimmed();
+            else if (line.startsWith(QLatin1String("Exec="))) exec = executableFromExecLine(line.mid(5).trimmed());
+            else if (line.startsWith(QLatin1String("Icon="))) icon = line.mid(5).trimmed();
+            else if (line.startsWith(QLatin1String("Comment="))) comment = line.mid(8).trimmed();
+        }
+
+        const QFileInfo executable(exec);
+
+        QVariantMap entry;
+        entry[QStringLiteral("id")] = identifier;
+        entry[QStringLiteral("name")] = name.isEmpty() ? identifier : name;
+        entry[QStringLiteral("exec")] = exec;
+        entry[QStringLiteral("path")] = exec;
+        entry[QStringLiteral("icon")] = resolveIcon(icon.isEmpty() ? identifier : icon);
+        entry[QStringLiteral("desktopFile")] = fileName;
+        entry[QStringLiteral("desktopPath")] = applications.filePath(fileName);
+        entry[QStringLiteral("summary")] = comment;
+        entry[QStringLiteral("size")] = executable.exists() ? humanSize(executable.size()) : QString();
+        entries.append(entry);
+
+        if (executable.exists()) seenPaths.insert(executable.absoluteFilePath());
+    }
+
+    for (const QString& directory : {portableDirectory(), binaryDirectory()}) {
+        QDir dir(directory);
+        if (!dir.exists()) continue;
+
+        const QStringList files = dir.entryList({QStringLiteral("*.AppImage"), QStringLiteral("*.appimage")}, QDir::Files, QDir::Name);
+        for (const QString& fileName : files) {
+            const QFileInfo info(dir.filePath(fileName));
+            if (seenPaths.contains(info.absoluteFilePath())) continue;
+            seenPaths.insert(info.absoluteFilePath());
+
+            QVariantMap entry;
+            entry[QStringLiteral("id")] = info.completeBaseName();
+            entry[QStringLiteral("name")] = info.completeBaseName();
+            entry[QStringLiteral("exec")] = info.absoluteFilePath();
+            entry[QStringLiteral("path")] = info.absoluteFilePath();
+            entry[QStringLiteral("icon")] = resolveIcon(slugify(info.completeBaseName()));
+            entry[QStringLiteral("summary")] = QString();
+            entry[QStringLiteral("size")] = humanSize(info.size());
+            entries.append(entry);
+        }
+    }
+
+    return entries;
+}
+
+QVariantMap AppImageInstaller::findInstalledAppImage(const QString& appIdentifier) {
+    if (appIdentifier.isEmpty()) return {};
+
+    QString identifier = appIdentifier;
+    if (identifier.startsWith(QLatin1String("file://"))) identifier = QUrl(identifier).toLocalFile();
+    const QString slug = slugify(identifier);
+
+    const QVariantList entries = installedAppImages();
+    const QStringList keys{QStringLiteral("desktopPath"), QStringLiteral("path"), QStringLiteral("id"), QStringLiteral("name")};
+    for (const QString& key : keys) {
+        for (const QVariant& value : entries) {
+            const QVariantMap entry = value.toMap();
+            if (entry.value(key).toString().compare(identifier, Qt::CaseInsensitive) == 0) return entry;
+        }
+    }
+
+    for (const QVariant& value : entries) {
+        const QVariantMap entry = value.toMap();
+        if (slugify(entry.value(QStringLiteral("id")).toString()) == slug) return entry;
+        if (slugify(entry.value(QStringLiteral("name")).toString()) == slug) return entry;
+    }
+
+    return {};
+}
+
 QVariantList AppImageInstaller::listInstalledAppImages() {
-    QVariantList list;
-    QString appsDir = QDir::homePath() + QStringLiteral("/.local/share/applications");
-    QDir dir(appsDir);
-
-    QStringList desktopFiles = dir.entryList({QStringLiteral("appimage-*.desktop")}, QDir::Files);
-    for (const QString& dFile : desktopFiles) {
-        QFile file(appsDir + QStringLiteral("/") + dFile);
-        if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            QVariantMap appMap;
-            appMap[QStringLiteral("desktopFile")] = dFile;
-            appMap[QStringLiteral("desktopPath")] = appsDir + QStringLiteral("/") + dFile;
-
-            QTextStream stream(&file);
-            while (!stream.atEnd()) {
-                QString line = stream.readLine().trimmed();
-                if (line.startsWith(QLatin1String("Name="))) {
-                    appMap[QStringLiteral("name")] = line.mid(5).trimmed();
-                } else if (line.startsWith(QLatin1String("Exec="))) {
-                    QString exec = line.mid(5).trimmed();
-                    exec.remove(QLatin1Char('"'));
-                    exec.remove(QStringLiteral(" %U"));
-                    appMap[QStringLiteral("exec")] = exec;
-                } else if (line.startsWith(QLatin1String("Icon="))) {
-                    appMap[QStringLiteral("icon")] = line.mid(5).trimmed();
-                }
-            }
-
-            QString icon = appMap.value(QStringLiteral("icon")).toString();
-            if (!icon.isEmpty() && !QFile::exists(icon)) {
-                QString iconsDir = QDir::homePath() + QStringLiteral("/.local/share/icons/hicolor/512x512/apps/");
-                if (QFile::exists(iconsDir + icon)) {
-                    appMap[QStringLiteral("icon")] = iconsDir + icon;
-                } else if (QFile::exists(iconsDir + icon + QStringLiteral(".png"))) {
-                    appMap[QStringLiteral("icon")] = iconsDir + icon + QStringLiteral(".png");
-                } else if (QFile::exists(iconsDir + icon + QStringLiteral(".svg"))) {
-                    appMap[QStringLiteral("icon")] = iconsDir + icon + QStringLiteral(".svg");
-                }
-            }
-
-            list.append(appMap);
-        }
-    }
-
-    return list;
+    return installedAppImages();
 }
 
-bool AppImageInstaller::uninstallAppImage(const QString& appName) {
-    QString safeName = appName.toLower();
-    safeName.replace(QRegularExpression(QStringLiteral("[^a-z0-9_-]")), QStringLiteral("-"));
+bool AppImageInstaller::uninstallAppImage(const QString& appIdentifier) {
+    const QVariantMap entry = findInstalledAppImage(appIdentifier);
+    if (entry.isEmpty()) return false;
 
-    QString desktopPath = QDir::homePath() + QStringLiteral("/.local/share/applications/appimage-") + safeName + QStringLiteral(".desktop");
-    QString binPath = QDir::homePath() + QStringLiteral("/.local/bin/") + safeName + QStringLiteral(".AppImage");
+    bool removed = false;
 
-    bool success = false;
-    if (QFile::exists(desktopPath)) {
-        success |= QFile::remove(desktopPath);
+    const QString executable = entry.value(QStringLiteral("path")).toString();
+    if (!executable.isEmpty() && QFile::exists(executable)) removed |= QFile::remove(executable);
+
+    const QString desktopPath = entry.value(QStringLiteral("desktopPath")).toString();
+    if (!desktopPath.isEmpty() && QFile::exists(desktopPath)) removed |= QFile::remove(desktopPath);
+
+    const QString icon = entry.value(QStringLiteral("icon")).toString();
+    if (icon.startsWith(iconDirectory()) && QFile::exists(icon)) QFile::remove(icon);
+
+    if (!desktopPath.isEmpty()) {
+        QProcess::startDetached(QStringLiteral("update-desktop-database"), {applicationsDirectory()});
     }
-    if (QFile::exists(binPath)) {
-        success |= QFile::remove(binPath);
-    }
 
-    QProcess::startDetached(QStringLiteral("update-desktop-database"), {QDir::homePath() + QStringLiteral("/.local/share/applications")});
-    return success;
+    return removed;
 }
 
-void AppImageInstaller::launchAppImage(const QString& appName) {
-    QString safeName = appName.toLower();
-    safeName.replace(QRegularExpression(QStringLiteral("[^a-z0-9_-]")), QStringLiteral("-"));
-    QString binPath = QDir::homePath() + QStringLiteral("/.local/bin/") + safeName + QStringLiteral(".AppImage");
-    if (QFile::exists(binPath)) {
-        QProcess::startDetached(binPath);
-    } else {
-        QString altBinPath = QDir::homePath() + QStringLiteral("/.local/bin/") + appName;
-        if (QFile::exists(altBinPath)) {
-            QProcess::startDetached(altBinPath);
-        }
-    }
+bool AppImageInstaller::launchAppImage(const QString& appIdentifier) {
+    const QVariantMap entry = findInstalledAppImage(appIdentifier);
+    const QString executable = entry.value(QStringLiteral("path")).toString();
+    if (executable.isEmpty() || !QFile::exists(executable)) return false;
+
+    return QProcess::startDetached(executable, {});
 }

--- a/src/marketplace/appimageinstaller.hpp
+++ b/src/marketplace/appimageinstaller.hpp
@@ -27,8 +27,11 @@ public:
 
     Q_INVOKABLE bool installAppImage(const QString& fileUrlOrPath);
     Q_INVOKABLE QVariantList listInstalledAppImages();
-    Q_INVOKABLE bool uninstallAppImage(const QString& appName);
-    Q_INVOKABLE void launchAppImage(const QString& appName);
+    Q_INVOKABLE bool uninstallAppImage(const QString& appIdentifier);
+    Q_INVOKABLE bool launchAppImage(const QString& appIdentifier);
+
+    static QVariantList installedAppImages();
+    static QVariantMap findInstalledAppImage(const QString& appIdentifier);
 
 signals:
     void isInstallingChanged();

--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -450,10 +450,9 @@ void PackageManager::uninstallPackage(const QString& backend, const QString& pac
 }
 
 void PackageManager::launchApp(const QString& backend, const QString& packageId, const QString& execPath) {
-    Q_UNUSED(execPath);
     IPackagePlugin* plugin = findPlugin(backend);
     if (plugin) {
-        plugin->launch(packageId);
+        plugin->launch(execPath.isEmpty() ? packageId : execPath);
     }
 }
 

--- a/src/marketplace/plugins/appimageplugin.cpp
+++ b/src/marketplace/plugins/appimageplugin.cpp
@@ -1,9 +1,9 @@
 #include "appimageplugin.hpp"
-#include <QDir>
-#include <QFile>
+#include "appimageinstaller.hpp"
+
 #include <QFileInfo>
 #include <QProcess>
-#include <QTextStream>
+#include <QUrl>
 
 AppImagePlugin::AppImagePlugin(QObject* parent) : IPackagePlugin(parent) {
     m_enabled = m_settings.value(QStringLiteral("AppImage/enabled"), true).toBool();
@@ -22,13 +22,13 @@ QVariantList AppImagePlugin::search(const QString& query, const QVariantMap& opt
     QVariantList results;
     if (!m_enabled) return results;
 
-    QVariantList installed = getInstalled();
-    QString q = query.trimmed().toLower();
-    for (const QVariant& v : installed) {
-        QVariantMap map = v.toMap();
-        if (map.value(QStringLiteral("name")).toString().toLower().contains(q) ||
-            map.value(QStringLiteral("id")).toString().toLower().contains(q)) {
-            results.append(map);
+    const QString needle = query.trimmed().toLower();
+    const QVariantList installed = getInstalled();
+    for (const QVariant& value : installed) {
+        const QVariantMap item = value.toMap();
+        if (item.value(QStringLiteral("name")).toString().toLower().contains(needle) ||
+            item.value(QStringLiteral("id")).toString().toLower().contains(needle)) {
+            results.append(item);
         }
     }
     return results;
@@ -38,101 +38,18 @@ QVariantList AppImagePlugin::getInstalled() {
     QVariantList results;
     if (!m_enabled) return results;
 
-    QSet<QString> seenIds;
-    QString iconsDir = QDir::homePath() + QStringLiteral("/.local/share/icons/hicolor/512x512/apps/");
-
-    // 1. Scan registered desktop files in ~/.local/share/applications
-    QString appsDir = QDir::homePath() + QStringLiteral("/.local/share/applications");
-    QDir dir(appsDir);
-    if (dir.exists()) {
-        QStringList desktopFiles = dir.entryList({QStringLiteral("appimage-*.desktop")}, QDir::Files);
-        for (const QString& dFile : desktopFiles) {
-            QFile file(appsDir + QStringLiteral("/") + dFile);
-            if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-                QVariantMap item;
-                item[QStringLiteral("backend")] = QStringLiteral("AppImage");
-                item[QStringLiteral("scope")] = QStringLiteral("user");
-                item[QStringLiteral("version")] = QStringLiteral("portable");
-                item[QStringLiteral("isInstalled")] = true;
-
-                QString baseId = dFile.mid(9); // strip "appimage-"
-                if (baseId.endsWith(QLatin1String(".desktop"))) {
-                    baseId.chop(8);
-                }
-                item[QStringLiteral("id")] = baseId;
-
-                QTextStream stream(&file);
-                while (!stream.atEnd()) {
-                    QString line = stream.readLine().trimmed();
-                    if (line.startsWith(QLatin1String("Name="))) {
-                        item[QStringLiteral("name")] = line.mid(5).trimmed();
-                    } else if (line.startsWith(QLatin1String("Exec="))) {
-                        QString exec = line.mid(5).trimmed();
-                        exec.remove(QLatin1Char('"'));
-                        exec.remove(QStringLiteral(" %U"));
-                        item[QStringLiteral("path")] = exec;
-                    } else if (line.startsWith(QLatin1String("Icon="))) {
-                        item[QStringLiteral("icon")] = line.mid(5).trimmed();
-                    } else if (line.startsWith(QLatin1String("Comment="))) {
-                        item[QStringLiteral("summary")] = line.mid(8).trimmed();
-                    }
-                }
-
-                if (item.value(QStringLiteral("name")).toString().isEmpty()) {
-                    item[QStringLiteral("name")] = baseId;
-                }
-
-                QString icon = item.value(QStringLiteral("icon")).toString();
-                if (!icon.isEmpty() && !QFile::exists(icon)) {
-                    if (QFile::exists(iconsDir + icon)) {
-                        item[QStringLiteral("icon")] = iconsDir + icon;
-                    } else if (QFile::exists(iconsDir + icon + QStringLiteral(".png"))) {
-                        item[QStringLiteral("icon")] = iconsDir + icon + QStringLiteral(".png");
-                    } else if (QFile::exists(iconsDir + icon + QStringLiteral(".svg"))) {
-                        item[QStringLiteral("icon")] = iconsDir + icon + QStringLiteral(".svg");
-                    }
-                }
-
-                seenIds.insert(baseId);
-                results.append(item);
-            }
+    const QVariantList entries = AppImageInstaller::installedAppImages();
+    for (const QVariant& value : entries) {
+        QVariantMap item = value.toMap();
+        item[QStringLiteral("backend")] = QStringLiteral("AppImage");
+        item[QStringLiteral("scope")] = QStringLiteral("user");
+        item[QStringLiteral("version")] = QStringLiteral("portable");
+        item[QStringLiteral("isInstalled")] = true;
+        if (item.value(QStringLiteral("icon")).toString().isEmpty()) {
+            item[QStringLiteral("icon")] = item.value(QStringLiteral("id"));
         }
+        results.append(item);
     }
-
-    // 2. Also check ~/Applications for any standalone AppImages not registered via desktop
-    QString standAloneDir = QDir::homePath() + QStringLiteral("/Applications");
-    QDir saDir(standAloneDir);
-    if (saDir.exists()) {
-        QStringList files = saDir.entryList({QStringLiteral("*.AppImage"), QStringLiteral("*.appimage")}, QDir::Files);
-        for (const QString& file : files) {
-            QFileInfo fi(saDir.filePath(file));
-            QString id = fi.baseName().toLower();
-            if (seenIds.contains(id)) continue;
-
-            QVariantMap item;
-            item[QStringLiteral("id")] = fi.baseName();
-            item[QStringLiteral("name")] = fi.baseName();
-            item[QStringLiteral("version")] = QStringLiteral("portable");
-            item[QStringLiteral("size")] = QString::number(fi.size() / (1024 * 1024)) + QStringLiteral(" MB");
-            item[QStringLiteral("backend")] = QStringLiteral("AppImage");
-            item[QStringLiteral("scope")] = QStringLiteral("user");
-            item[QStringLiteral("path")] = fi.absoluteFilePath();
-            item[QStringLiteral("isInstalled")] = true;
-
-            QString icon = fi.baseName();
-            if (QFile::exists(iconsDir + icon + QStringLiteral(".png"))) {
-                item[QStringLiteral("icon")] = iconsDir + icon + QStringLiteral(".png");
-            } else if (QFile::exists(iconsDir + icon + QStringLiteral(".svg"))) {
-                item[QStringLiteral("icon")] = iconsDir + icon + QStringLiteral(".svg");
-            } else {
-                item[QStringLiteral("icon")] = icon;
-            }
-
-            seenIds.insert(id);
-            results.append(item);
-        }
-    }
-
     return results;
 }
 
@@ -141,40 +58,60 @@ QVariantList AppImagePlugin::getUpdates() {
 }
 
 QVariantMap AppImagePlugin::getDetails(const QString& packageId) {
-    QVariantMap map;
-    map[QStringLiteral("id")] = packageId;
-    map[QStringLiteral("name")] = packageId;
+    QVariantMap map = AppImageInstaller::findInstalledAppImage(packageId);
+    map[QStringLiteral("id")] = map.value(QStringLiteral("id"), packageId);
+    map[QStringLiteral("name")] = map.value(QStringLiteral("name"), packageId);
     map[QStringLiteral("backend")] = QStringLiteral("AppImage");
-    map[QStringLiteral("summary")] = QStringLiteral("Standalone AppImage application");
-    map[QStringLiteral("description")] = QStringLiteral("Standalone AppImage application");
+    map[QStringLiteral("version")] = QStringLiteral("portable");
+
+    const QString summary = map.value(QStringLiteral("summary")).toString();
+    if (summary.isEmpty()) {
+        map[QStringLiteral("summary")] = QStringLiteral("Standalone AppImage application");
+    }
+    map[QStringLiteral("description")] = map.value(QStringLiteral("path")).toString().isEmpty()
+        ? map.value(QStringLiteral("summary"))
+        : map.value(QStringLiteral("path"));
+
     return map;
 }
 
 bool AppImagePlugin::install(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
-    Q_UNUSED(packageId);
     Q_UNUSED(options);
-    Q_UNUSED(progressCb);
-    return false;
+    if (!m_enabled) return false;
+
+    QString path = packageId;
+    if (path.startsWith(QLatin1String("file://"))) path = QUrl(path).toLocalFile();
+
+    const QFileInfo info(path);
+    if (!info.exists() || !info.isFile()) {
+        if (progressCb) progressCb(0, QStringLiteral("AppImage file not found: ") + path);
+        return false;
+    }
+
+    if (progressCb) progressCb(10, QStringLiteral("Installing ") + info.fileName());
+
+    AppImageInstaller installer;
+    const bool installed = installer.installAppImage(info.absoluteFilePath());
+
+    if (progressCb) progressCb(installed ? 100 : 0, installer.statusMessage());
+    return installed;
 }
 
 bool AppImagePlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     Q_UNUSED(options);
-    Q_UNUSED(progressCb);
-    QString appDir = QDir::homePath() + QStringLiteral("/Applications");
-    QDir dir(appDir);
-    QStringList files = dir.entryList({packageId + QStringLiteral("*.AppImage"), packageId + QStringLiteral("*.appimage")}, QDir::Files);
-    for (const QString& file : files) {
-        QFile::remove(dir.filePath(file));
+
+    AppImageInstaller installer;
+    const bool removed = installer.uninstallAppImage(packageId);
+
+    if (progressCb) {
+        progressCb(removed ? 100 : 0, removed
+            ? QStringLiteral("Removed ") + packageId
+            : QStringLiteral("No installed AppImage matches ") + packageId);
     }
-    return true;
+    return removed;
 }
 
 bool AppImagePlugin::launch(const QString& packageId) {
-    QString appDir = QDir::homePath() + QStringLiteral("/Applications");
-    QDir dir(appDir);
-    QStringList files = dir.entryList({packageId + QStringLiteral("*.AppImage"), packageId + QStringLiteral("*.appimage")}, QDir::Files);
-    if (!files.isEmpty()) {
-        return QProcess::startDetached(dir.filePath(files.first()));
-    }
-    return false;
+    AppImageInstaller installer;
+    return installer.launchAppImage(packageId);
 }


### PR DESCRIPTION
## Problems

**1. Installer and plugin use different directories.** `AppImageInstaller::installAppImage()` copies to `~/.local/bin/<slug>.AppImage` and writes `~/.local/share/applications/appimage-<slug>.desktop`, but `AppImagePlugin::launch()` and `::uninstall()` look for `~/Applications/<id>*.AppImage`. Everything installed through Astra is therefore unreachable from the plugin — and `uninstall()` returns `true` regardless, so the UI reports a successful removal while binary, desktop entry and icon stay on disk.

**2. The AppImage page resolves by display name.** The page calls `uninstallAppImage(modelData.name)` / `launchAppImage(modelData.name)`, and both slugify that display name to find the file. The installed file name comes from the *file*, not from the `Name=` in the embedded desktop entry, so the two differ for nearly every real AppImage.

Reproduced with a fixture whose file is `Astra Test App-2.1-x86_64.AppImage` and whose `Name=` is `Astra Test App`:

```
old launch by display name  -> nothing happens (no process started)
old uninstall by display name -> false, nothing removed
astra remove <id> --source AppImage -> "✓ Successfully removed", all three files still present
```

**3. `PackageManager::launchApp()` accepts an `execPath` and discards it** (`Q_UNUSED`), so callers that know the path cannot use it.

## Change

`AppImageInstaller` gains one registry used by everything else:

- `installedAppImages()` enumerates `appimage-*.desktop` entries (id, display name, executable from `Exec=`, resolved icon, desktop path, size) and adds standalone AppImages from `~/Applications` and `~/.local/bin` that no desktop entry covers.
- `findInstalledAppImage()` resolves an identifier by desktop path, executable path, id or display name, and falls back to comparing slugs so existing callers keep working.
- `uninstallAppImage()` removes the executable, the desktop entry and the icon that the installer extracted, and returns whether anything was actually removed. `launchAppImage()` starts the executable from the entry and returns a bool.
- `AppImagePlugin` delegates to that registry for search/list/details/launch/uninstall, `install()` accepts a file path or `file://` URL and delegates to the installer, and details expose the real path and size instead of a fixed placeholder string.
- `PackageManager::launchApp()` passes a non-empty `execPath` to the plugin.
- The AppImage page passes the unique desktop path instead of the display name.

## Testing

Fixture AppImage (`Astra Test App-2.1-x86_64.AppImage`, `Name=Astra Test App`) installed through `astra install <file>`:

| case | 1.1.0 | this branch |
| --- | --- | --- |
| `astra remove astra-test-app-2-1-x86_64 --source AppImage` | reports success, binary + desktop entry + icon remain | all three removed, reported correctly |
| launch by display name (what the AppImage page does) | no process started | process started |
| uninstall by display name | `false`, nothing removed | resolves and removes |
| listing | desktop entries only | desktop entries plus standalone AppImages in `~/Applications` / `~/.local/bin`, with path and size |
| unknown identifier | reported as success | `false`, message in the log |

`astra install`, `astra list` and `astra remove` verified on the CLI, and the resolution/launch paths verified directly against the compiled `AppImageInstaller` (lookup by display name and by id both resolve to the installed file, unknown identifiers miss, launch actually starts the process). GUI starts and renders unchanged; an existing standalone AppImage in `~/Applications` is picked up without being touched.