### PR TITLE
fix(ipc): make the single instance commands work and restrict the socket

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -204,7 +204,6 @@ public:
 #include "tray/traymanager.hpp"
 #include <QApplication>
 #include <QQmlContext>
-#include <QQuickWindow>
 #include <QLocalServer>
 #include <QLocalSocket>
 
@@ -382,49 +381,30 @@ int main(int argc, char* argv[]) {
             QCoreApplication::exit(-1);
     }, Qt::QueuedConnection);
 
-    QObject::connect(TrayManager::instance(), &TrayManager::requestShowMainWindow, [&engine]() {
-        const auto rootObjects = engine.rootObjects();
-        for (auto* obj : rootObjects) {
-            if (auto* window = qobject_cast<QQuickWindow*>(obj)) {
-                window->setVisible(true);
-                window->show();
-                window->raise();
-                window->requestActivate();
-            }
-        }
-    });
-
-    QObject::connect(TrayManager::instance(), &TrayManager::requestToggleMainWindow, [&engine]() {
-        const auto rootObjects = engine.rootObjects();
-        for (auto* obj : rootObjects) {
-            if (auto* window = qobject_cast<QQuickWindow*>(obj)) {
-                if (window->isVisible()) {
-                    window->setVisible(false);
-                } else {
-                    window->setVisible(true);
-                    window->show();
-                    window->raise();
-                    window->requestActivate();
-                }
-            }
-        }
-    });
-
-    QLocalServer::removeServer(serverName);
     auto* ipcServer = new QLocalServer(&app);
-    QObject::connect(ipcServer, &QLocalServer::newConnection, [ipcServer]() {
+    ipcServer->setSocketOptions(QLocalServer::UserAccessOption);
+    QObject::connect(ipcServer, &QLocalServer::newConnection, ipcServer, [ipcServer]() {
         while (QLocalSocket* client = ipcServer->nextPendingConnection()) {
-            QObject::connect(client, &QLocalSocket::readyRead, [client]() {
-                const QByteArray cmd = client->readAll().trimmed();
-                if (cmd == "SHOW" || cmd == "OPEN_GUI") {
-                    TrayManager::instance()->showMainWindow();
-                } else if (cmd == "TOGGLE") {
-                    TrayManager::instance()->toggleMainWindow();
+            QObject::connect(client, &QLocalSocket::disconnected, client, &QLocalSocket::deleteLater);
+            QObject::connect(client, &QLocalSocket::readyRead, client, [client]() {
+                while (client->canReadLine()) {
+                    const QByteArray command = client->readLine().trimmed();
+                    if (command == "SHOW" || command == "OPEN_GUI") {
+                        TrayManager::instance()->showMainWindow();
+                    } else if (command == "TOGGLE") {
+                        TrayManager::instance()->toggleMainWindow();
+                    } else if (command == "TRAY") {
+                        TrayManager::instance()->setTrayEnabled(true);
+                    }
                 }
             });
         }
     });
-    ipcServer->listen(serverName);
+
+    if (!ipcServer->listen(serverName) && ipcServer->serverError() == QAbstractSocket::AddressInUseError) {
+        QLocalServer::removeServer(serverName);
+        ipcServer->listen(serverName);
+    }
 
     engine.rootContext()->setContextProperty(QStringLiteral("startInTray"), launchTray);
     engine.rootContext()->setContextProperty(QStringLiteral("appVersion"), QStringLiteral(ASTRA_VERSION));


### PR DESCRIPTION
## Problems

**1. `--tray` on a running instance does nothing.** The second process sends `TRAY`, but the server only accepts `SHOW`, `OPEN_GUI` and `TOGGLE`.

**2. Toggling the window never hides it.** `requestToggleMainWindow` is handled *twice* — once by a lambda in `main.cpp` that flips `window->setVisible()` and once by the `Connections` block in `Main.qml` that calls `window.hide()`/`show()`. Both run, so the second undoes the first:

```
after start --tray: astra windows=0
sent SHOW           astra windows=1
sent TOGGLE         astra windows=1   <-- expected 0
```

**3. The socket is world accessible and stomped on startup.** `QLocalServer::removeServer()` is called unconditionally *before* `listen()`, so a second instance racing with the first deletes the socket the first one is serving. No socket options are set either:

```
srwxr-xr-x  astra-market-single-instance-vladi      (1.1.0)
srwx------  astra-market-single-instance-astratest  (this branch)
```

Client sockets are also never deleted, so every `astra --gui` against a running instance leaks a `QLocalSocket`.

## Change

- `TRAY` is handled: it makes sure the tray icon is enabled without pulling the window up.
- The duplicate C++ show/toggle handlers are removed; `Main.qml` keeps handling both signals (it is also the side that knows about the close-to-tray setting).
- `listen()` is attempted first and the stale socket is only removed when it fails with `AddressInUseError`.
- `QLocalServer::UserAccessOption` restricts the socket to the owning user.
- Commands are read line by line and client sockets are deleted on disconnect.

## Testing

Against a running instance (`--tray`, i.e. started hidden), Hyprland window count:

| step | 1.1.0 | this branch |
| --- | --- | --- |
| start `--tray` | 0 | 0 |
| `SHOW` | 1 | 1 |
| `TOGGLE` | 1 | 0 |
| `astra --gui` | 1 | 1 |
| `astra --tray` | ignored | tray icon ensured, window untouched |

Socket permissions verified as `srwx------`. GUI start, `--gui` on a fresh session and CLI commands unchanged.