### PR TITLE
chore: build shaders portably and check every push

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Attach
+ColumnLimit: 140
+DerivePointerAlignment: false
+IndentWidth: 4
+NamespaceIndentation: None
+PointerAlignment: Left
+SortIncludes: false
+SpaceAfterTemplateKeyword: false
+Standard: c++20

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+
+    steps:
+      - name: Install dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm --needed \
+            base-devel \
+            git \
+            cmake \
+            ninja \
+            qt6-base \
+            qt6-declarative \
+            qt6-shadertools \
+            qt6-svg
+
+      - name: Mark git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DASTRA_BUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure --no-tests=ignore
+
+      - name: Install
+        run: DESTDIR="$GITHUB_WORKSPACE/install-check" cmake --install build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,29 +31,25 @@ find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Quick QuickControls2 Shade
 
 qt_standard_project_setup(REQUIRES 6.5)
 
-# Custom qsb command for blob shaders
-add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/shaders/blob.vert.qsb
-           ${CMAKE_CURRENT_SOURCE_DIR}/shaders/blob.frag.qsb
-    COMMAND /usr/lib/qt6/bin/qsb --glsl 300es,120,150,330,450 -b -O --hlsl 50 --msl 20000 -o ${CMAKE_CURRENT_SOURCE_DIR}/shaders/blob.vert.qsb ${CMAKE_CURRENT_SOURCE_DIR}/shaders/blob.vert
-    COMMAND /usr/lib/qt6/bin/qsb --glsl 300es,120,150,330,450 -b -O --hlsl 50 --msl 20000 -o ${CMAKE_CURRENT_SOURCE_DIR}/shaders/blob.frag.qsb ${CMAKE_CURRENT_SOURCE_DIR}/shaders/blob.frag
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/shaders/blob.vert
-            ${CMAKE_CURRENT_SOURCE_DIR}/shaders/blob.frag
-    COMMENT "Compiling QSB shaders"
-)
-
 # C++ Source files
 file(GLOB_RECURSE PROJECT_SOURCES CONFIGURE_DEPENDS
     "src/*.cpp"
     "src/*.hpp"
 )
 
-list(APPEND PROJECT_SOURCES
-    shaders/blob.vert.qsb
-    shaders/blob.frag.qsb
-)
-
 qt_add_executable(astra ${PROJECT_SOURCES})
+
+qt_add_shaders(astra "blob_shaders"
+    BATCHABLE
+    OPTIMIZED
+    PREFIX "/"
+    GLSL "300es,120,150,330,450"
+    HLSL 50
+    MSL 20000
+    FILES
+        shaders/blob.vert
+        shaders/blob.frag
+)
 
 target_include_directories(astra PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -87,8 +83,6 @@ qt_add_resources(astra "resources"
         assets/icons/tray-dark.svg
         assets/icons/tray-light.svg
         assets/fonts/GoogleSansFlex-VariableFont_GRAD,ROND,opsz,slnt,wdth,wght.ttf
-        shaders/blob.vert.qsb
-        shaders/blob.frag.qsb
 )
 
 # Add QML files with CONFIGURE_DEPENDS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to AstraMarket
+
+## Building
+
+```bash
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+./build/astra --gui
+```
+
+Required at build time: CMake >= 3.19, a C++20 compiler and Qt 6.5 or newer with the Core, Gui,
+Widgets, Quick, QuickControls2, ShaderTools, Concurrent, Network, DBus and Svg modules.
+
+## Tests
+
+```bash
+cmake -B build -G Ninja -DASTRA_BUILD_TESTS=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+The tests cover the backend output parsers and the process helper. Anything that parses the output of
+`pacman`, `flatpak` or an AUR helper should come with a fixture in `tests/`; those parsers are static
+functions so they can be tested without running the tools.
+
+Every push and pull request builds on Arch Linux and runs the test suite (`.github/workflows/build.yml`).
+
+## Code style
+
+- `.clang-format` describes the C++ style: four spaces, attached braces, pointers bound to the type.
+  Format the lines you touch, not whole files.
+- `.editorconfig` covers the rest (LF, UTF-8, trailing whitespace).
+- QML follows the structure of the existing pages: tokens from `AstraMarket.Config` for sizing, spacing
+  and typography, colours from `qs.services` (`Colours.palette`), and the shared components in
+  `qml/qs/components` instead of raw `Rectangle`/`Text` items.
+- User visible strings go through `qsTr()`.
+
+## Backends
+
+A new package source is either a `IPackagePlugin` subclass in `src/marketplace/plugins/` registered in
+`PackageManager::initPlugins()`, or a scriptable plugin described by a `plugin.json` manifest — see
+[PLUGINS.md](PLUGINS.md). Run external commands through `astra::runProcess()` /
+`astra::runProcessStreaming()` so they get a fixed locale, a timeout and line based output.
+
+## Commits and pull requests
+
+- Conventional commit subjects (`fix(cli): …`, `feat(details): …`, `chore: …`), imperative mood.
+- Describe what was broken and how it was verified. Numbers, command output or screenshots help.
+- One topic per pull request.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@ AstraMarket is a unified package manager providing both a graphical interface an
 
 ## Requirements
 
-- Qt 6 (Core, Gui, Quick, QuickControls2, ShaderTools, Concurrent, Network, DBus, Svg)
+Build:
+
+- Qt 6.5+ (Core, Gui, Widgets, Quick, QuickControls2, ShaderTools, Concurrent, Network, DBus, Svg)
 - CMake (>= 3.19)
 - C++20 compiler
-- Supported package managers: Flatpak, Pacman, paru/yay (optional for AUR)
+
+Runtime, all optional — a source that is not installed is simply inactive:
+
+- `flatpak` for the Flatpak source
+- `pacman` for the Pacman source, plus `pacman-contrib` for `checkupdates` (without it no Pacman
+  updates are reported) and a PolicyKit authentication agent for installing and removing packages
+- `paru` or `yay` for the AUR source
+- `update-desktop-database` (`desktop-file-utils`) for AppImage desktop integration
 
 ## Installation
 
@@ -116,6 +125,10 @@ astra --help
 ## Plugins
 
 For creating and installing custom package sources or scrapers, see [PLUGINS](PLUGINS.md).
+
+## Contributing
+
+Build instructions, the test setup and the code style are described in [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Problems

**1. The shader step hardcodes the Qt path.**

```cmake
COMMAND /usr/lib/qt6/bin/qsb --glsl 300es,120,150,330,450 -b -O … -o ${CMAKE_CURRENT_SOURCE_DIR}/shaders/blob.vert.qsb …
```

That path is Arch specific — on Fedora the tool lives in `/usr/lib64/qt6/bin`, on Debian in `/usr/lib/qt6/libexec`, and in a self-built or `aqt` Qt anywhere else — so the build fails there for a reason that has nothing to do with the code. It also writes the compiled shaders into the source tree.

**2. CI only runs on tags.** `release.yml` triggers on `v*`, so nothing builds a branch or a pull request; a change that does not compile is only noticed at release time.

## Change

- `qt_add_shaders(astra "blob_shaders" …)` replaces the custom command with the same options (`BATCHABLE`, `OPTIMIZED`, GLSL `300es,120,150,330,450`, HLSL 50, MSL 20000). It uses the `qsb` from the Qt that CMake found and emits `:/shaders/blob.vert.qsb` and `:/shaders/blob.frag.qsb`, exactly the paths `BlobMaterial` loads, so nothing else changes. The `.qsb` files no longer land in the source tree, and the now-redundant resource entries are gone.
- `.github/workflows/build.yml` builds on Arch for every push to `main` and every pull request: configure, build, `ctest --output-on-failure --no-tests=ignore`, and a `DESTDIR` install to catch broken install rules. The test step is a no-op until the test target from #4 exists, and picks it up automatically afterwards.
- `CONTRIBUTING.md` documents building, running the tests, the code style, how to add a backend and the commit conventions.
- `.clang-format` (four spaces, attached braces, `Type* name`, 140 columns) and `.editorconfig` describe the existing style for new code — no existing file is reformatted.
- The README requirement list now separates build from runtime dependencies and names the optional ones that silently disable a feature: `pacman-contrib` for `checkupdates`, a PolicyKit agent for pacman operations, `desktop-file-utils` for AppImage integration.

## Testing

- Clean build from a tree without any `*.qsb`: shaders are generated into `build/.qsb/shaders/` and the GUI renders the blob background as before.
- `cmake --build build && ctest --test-dir build --no-tests=ignore` → rc 0, and `DESTDIR=… cmake --install build` installs the same files.
- Both workflow files parse as YAML.