### PR TITLE
feat(cli): apply updates, emit json and stop colouring pipes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,3 +148,16 @@ install(FILES assets/polkit/com.astramarket.pacman.policy
     DESTINATION ${CMAKE_INSTALL_DATADIR}/polkit-1/actions
 )
 
+install(FILES assets/completions/astra.bash
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/bash-completion/completions
+    RENAME astra
+)
+
+install(FILES assets/completions/_astra
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/zsh/site-functions
+)
+
+install(FILES assets/completions/astra.fish
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/fish/vendor_completions.d
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,38 @@ qt_add_resources(astra "qml_resources"
     FILES ${QML_FILES}
 )
 
+option(ASTRA_BUILD_TESTS "Build the AstraMarket unit tests" OFF)
+
+if(ASTRA_BUILD_TESTS)
+    enable_testing()
+    find_package(Qt6 REQUIRED COMPONENTS Test)
+
+    qt_add_executable(tst_parsers
+        tests/tst_parsers.cpp
+        src/marketplace/pluginprocess.cpp
+        src/marketplace/pluginprocess.hpp
+        src/marketplace/plugins/packageplugin.hpp
+        src/marketplace/plugins/pacmanplugin.cpp
+        src/marketplace/plugins/pacmanplugin.hpp
+        src/marketplace/plugins/flatpakplugin.cpp
+        src/marketplace/plugins/flatpakplugin.hpp
+    )
+
+    target_include_directories(tst_parsers PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/marketplace
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/marketplace/plugins
+    )
+
+    target_link_libraries(tst_parsers PRIVATE
+        Qt6::Core
+        Qt6::Network
+        Qt6::Test
+    )
+
+    add_test(NAME parsers COMMAND tst_parsers)
+endif()
+
 # Installation
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ Search across enabled package sources:
 ```bash
 astra search <query>
 astra search <query> --source <Flatpak|Pacman|AUR|AppImage>
+astra search <query> --json
 ```
+
+When no `--source` is given, the source is resolved from the package id: an ambiguous id lists the
+sources that provide it, so `astra install yay --source AUR` picks the AUR package rather than the
+repository one.
 
 Install a package:
 
@@ -97,10 +102,18 @@ List installed packages:
 astra list
 ```
 
-Check for updates:
+List available updates:
 
 ```bash
 astra update
+astra update --json
+```
+
+Apply updates, either everything or a single package:
+
+```bash
+astra upgrade
+astra upgrade <package-id>
 ```
 
 View package details:
@@ -121,6 +134,11 @@ Show help and all available commands:
 ```bash
 astra --help
 ```
+
+Output is coloured only when it goes to a terminal; `--no-color` and `NO_COLOR` disable it, and
+`--json` prints machine readable output for `search`, `list`, `update`, `info` and `sources`.
+
+Completions for bash, zsh and fish are installed alongside the binary.
 
 ## Privileges
 

--- a/assets/completions/_astra
+++ b/assets/completions/_astra
@@ -1,0 +1,31 @@
+#compdef astra
+
+local state
+local -a commands
+
+commands=(
+    'search:Search for packages across all or specific sources'
+    'install:Install a package or a local .AppImage file'
+    'remove:Uninstall a package'
+    'list:List installed packages'
+    'update:List available updates'
+    'upgrade:Apply updates, all of them or a single package'
+    'info:Display metadata and details for a package'
+    'sources:List registered package plugins and sources'
+    'gui:Launch the graphical interface'
+    'tray:Launch minimized in system tray'
+)
+
+_arguments -C \
+    '(-s --source)'{-s,--source}'[target a specific package source]:source:(Flatpak Pacman AUR AppImage)' \
+    '--scope[installation scope]:scope:(user system)' \
+    '--json[print machine readable output]' \
+    '--no-color[disable coloured output]' \
+    '(-h --help)'{-h,--help}'[show help]' \
+    '(-v --version)'{-v,--version}'[show version]' \
+    '1: :->command' \
+    '*:: :_files'
+
+if [[ $state == command ]]; then
+    _describe -t commands 'astra command' commands
+fi

--- a/assets/completions/astra.bash
+++ b/assets/completions/astra.bash
@@ -1,0 +1,34 @@
+_astra() {
+    local cur prev commands options sources scopes
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    commands="search install remove uninstall list update upgrade info sources plugins gui tray help version"
+    options="--source --scope --json --no-color --help --version"
+    sources="Flatpak Pacman AUR AppImage"
+    scopes="user system"
+
+    case "$prev" in
+        -s|--source)
+            COMPREPLY=($(compgen -W "$sources" -- "$cur"))
+            return
+            ;;
+        --scope)
+            COMPREPLY=($(compgen -W "$scopes" -- "$cur"))
+            return
+            ;;
+    esac
+
+    if [[ $cur == -* ]]; then
+        COMPREPLY=($(compgen -W "$options" -- "$cur"))
+        return
+    fi
+
+    if [[ $COMP_CWORD -eq 1 ]]; then
+        COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+        return
+    fi
+
+    COMPREPLY=($(compgen -f -- "$cur"))
+}
+
+complete -F _astra astra

--- a/assets/completions/astra.fish
+++ b/assets/completions/astra.fish
@@ -1,0 +1,21 @@
+set -l astra_commands search install remove uninstall list update upgrade info sources plugins gui tray help version
+
+complete -c astra -f
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a search -d 'Search for packages across all or specific sources'
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a install -d 'Install a package or a local .AppImage file'
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a remove -d 'Uninstall a package'
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a list -d 'List installed packages'
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a update -d 'List available updates'
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a upgrade -d 'Apply updates, all of them or a single package'
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a info -d 'Display metadata and details for a package'
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a sources -d 'List registered package plugins and sources'
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a gui -d 'Launch the graphical interface'
+complete -c astra -n "not __fish_seen_subcommand_from $astra_commands" -a tray -d 'Launch minimized in system tray'
+
+complete -c astra -s s -l source -x -a 'Flatpak Pacman AUR AppImage' -d 'Package source'
+complete -c astra -l scope -x -a 'user system' -d 'Installation scope'
+complete -c astra -l json -d 'Print machine readable output'
+complete -c astra -l no-color -d 'Disable coloured output'
+complete -c astra -s h -l help -d 'Show help'
+complete -c astra -s v -l version -d 'Show version'
+complete -c astra -n "__fish_seen_subcommand_from install" -F

--- a/qml/qs/modules/astra/pages/AppDetailPage.qml
+++ b/qml/qs/modules/astra/pages/AppDetailPage.qml
@@ -20,6 +20,18 @@ PageBase {
     property bool isInstalled: false
     property var infoMap: null
     readonly property var screenshotsList: (root.infoMap && root.infoMap.screenshots) ? root.infoMap.screenshots : []
+    readonly property string detailUrl: (root.infoMap && (root.infoMap.url || root.infoMap.homepage)) ? (root.infoMap.url || root.infoMap.homepage) : ""
+    readonly property string detailLicenses: (root.infoMap && (root.infoMap.licenses || root.infoMap.license)) ? (root.infoMap.licenses || root.infoMap.license) : ""
+    readonly property string detailInstalledSize: (root.infoMap && (root.infoMap.installedSize || root.infoMap.size)) ? (root.infoMap.installedSize || root.infoMap.size) : ""
+    readonly property string detailDownloadSize: (root.infoMap && root.infoMap.downloadSize) ? root.infoMap.downloadSize : ""
+    readonly property string detailBuildDate: (root.infoMap && root.infoMap.buildDate) ? root.infoMap.buildDate : ""
+    readonly property string detailInstallReason: (root.infoMap && root.infoMap.installReason) ? root.infoMap.installReason : ""
+    readonly property string detailProvides: (root.infoMap && root.infoMap.provides) ? root.infoMap.provides : ""
+    readonly property string detailMaintainer: (root.infoMap && root.infoMap.developer) ? root.infoMap.developer : ""
+    readonly property int detailVotes: (root.infoMap && root.infoMap.votes) ? root.infoMap.votes : 0
+    readonly property real detailPopularity: (root.infoMap && root.infoMap.popularity) ? root.infoMap.popularity : 0
+    readonly property bool detailOutOfDate: !!(root.infoMap && root.infoMap.outOfDate)
+    readonly property bool detailOrphaned: !!(root.infoMap && root.infoMap.orphaned)
     readonly property var dependsList: (root.infoMap && root.infoMap.depends) ? root.infoMap.depends : []
     readonly property var requiredByList: (root.infoMap && root.infoMap.requiredBy) ? root.infoMap.requiredBy : []
 
@@ -654,45 +666,124 @@ PageBase {
                     }
 
                     StyledText {
+                        visible: root.detailInstalledSize !== ""
                         text: qsTr("Installed Size")
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurfaceVariant
                     }
                     StyledText {
-                        text: (root.infoMap && root.infoMap.installedSize) ? root.infoMap.installedSize : "N/A"
+                        visible: root.detailInstalledSize !== ""
+                        text: root.detailInstalledSize
                         font: Tokens.font.body.medium
                         color: Colours.palette.m3onSurface
                     }
 
                     StyledText {
+                        visible: root.detailDownloadSize !== ""
+                        text: qsTr("Download Size")
+                        font: Tokens.font.label.large
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+                    StyledText {
+                        visible: root.detailDownloadSize !== ""
+                        text: root.detailDownloadSize
+                        font: Tokens.font.body.medium
+                        color: Colours.palette.m3onSurface
+                    }
+
+                    StyledText {
+                        visible: root.detailBuildDate !== ""
                         text: qsTr("Build Date")
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurfaceVariant
                     }
                     StyledText {
-                        text: (root.infoMap && root.infoMap.buildDate) ? root.infoMap.buildDate : "N/A"
+                        visible: root.detailBuildDate !== ""
+                        text: root.detailBuildDate
                         font: Tokens.font.body.medium
                         color: Colours.palette.m3onSurface
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
                     }
 
                     StyledText {
+                        visible: root.detailInstallReason !== ""
                         text: qsTr("Install Reason")
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurfaceVariant
                     }
                     StyledText {
-                        text: (root.infoMap && root.infoMap.installReason) ? root.infoMap.installReason : "Explicitly installed"
+                        visible: root.detailInstallReason !== ""
+                        text: root.detailInstallReason
+                        font: Tokens.font.body.medium
+                        color: Colours.palette.m3onSurface
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                    }
+
+                    StyledText {
+                        visible: root.detailVotes > 0
+                        text: qsTr("Votes")
+                        font: Tokens.font.label.large
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+                    StyledText {
+                        visible: root.detailVotes > 0
+                        text: root.detailVotes
                         font: Tokens.font.body.medium
                         color: Colours.palette.m3onSurface
                     }
 
                     StyledText {
+                        visible: root.detailPopularity > 0
+                        text: qsTr("Popularity")
+                        font: Tokens.font.label.large
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+                    StyledText {
+                        visible: root.detailPopularity > 0
+                        text: root.detailPopularity.toFixed(2)
+                        font: Tokens.font.body.medium
+                        color: Colours.palette.m3onSurface
+                    }
+
+                    StyledText {
+                        visible: root.detailMaintainer !== "" || root.detailOrphaned
+                        text: root.appData && root.appData.backend === "AUR" ? qsTr("Maintainer") : qsTr("Packager")
+                        font: Tokens.font.label.large
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+                    StyledText {
+                        visible: root.detailMaintainer !== "" || root.detailOrphaned
+                        text: root.detailMaintainer !== "" ? root.detailMaintainer : qsTr("Orphaned")
+                        font: Tokens.font.body.medium
+                        color: root.detailMaintainer !== "" ? Colours.palette.m3onSurface : Colours.palette.m3error
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                    }
+
+                    StyledText {
+                        visible: root.detailOutOfDate
+                        text: qsTr("Status")
+                        font: Tokens.font.label.large
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+                    StyledText {
+                        visible: root.detailOutOfDate
+                        text: qsTr("Flagged out of date")
+                        font: Tokens.font.body.medium
+                        color: Colours.palette.m3error
+                    }
+
+                    StyledText {
+                        visible: root.detailUrl !== ""
                         text: qsTr("URL")
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurfaceVariant
                     }
                     StyledText {
-                        text: (root.infoMap && root.infoMap.url) ? root.infoMap.url : "N/A"
+                        visible: root.detailUrl !== ""
+                        text: root.detailUrl
                         font: Tokens.font.body.medium
                         color: Colours.palette.m3primary
                         elide: Text.ElideRight
@@ -701,32 +792,38 @@ PageBase {
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: {
-                                if (root.infoMap && root.infoMap.url) Qt.openUrlExternally(root.infoMap.url);
-                            }
+                            onClicked: Qt.openUrlExternally(root.detailUrl)
                         }
                     }
 
                     StyledText {
+                        visible: root.detailLicenses !== ""
                         text: qsTr("Licenses")
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurfaceVariant
                     }
                     StyledText {
-                        text: (root.infoMap && root.infoMap.licenses) ? root.infoMap.licenses : "Proprietary / Open Source"
+                        visible: root.detailLicenses !== ""
+                        text: root.detailLicenses
                         font: Tokens.font.body.medium
                         color: Colours.palette.m3onSurface
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
                     }
 
                     StyledText {
+                        visible: root.detailProvides !== ""
                         text: qsTr("Provides")
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurfaceVariant
                     }
                     StyledText {
-                        text: (root.infoMap && root.infoMap.provides) ? root.infoMap.provides : (root.appData ? root.appData.id : "N/A")
+                        visible: root.detailProvides !== ""
+                        text: root.detailProvides
                         font: Tokens.font.body.medium
                         color: Colours.palette.m3onSurface
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
                     }
                 }
 

--- a/qml/qs/modules/astra/pages/AppDetailPage.qml
+++ b/qml/qs/modules/astra/pages/AppDetailPage.qml
@@ -309,7 +309,7 @@ PageBase {
                         activeOnColour: Colours.palette.m3error
                         onClicked: {
                             if (root.appData) {
-                                PackageManager.uninstallPackage(root.appData.backend || "", root.appData.id || "");
+                                PackageManager.uninstallPackage(root.appData.backend || "", root.appData.id || "", root.selectedScope);
                             }
                         }
                     }

--- a/qml/qs/modules/astra/pages/UpdatesPage.qml
+++ b/qml/qs/modules/astra/pages/UpdatesPage.qml
@@ -238,7 +238,7 @@ PageBase {
                         enabled: !PackageManager.isBusy
                         Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                         onClicked: {
-                            PackageManager.installPackage(cardRect.modelData.backend, cardRect.modelData.id, cardRect.modelData.scope || "user");
+                            PackageManager.updatePackage(cardRect.modelData.backend, cardRect.modelData.id, cardRect.modelData.scope || "");
                         }
                     }
 

--- a/src/cli/clihandler.cpp
+++ b/src/cli/clihandler.cpp
@@ -278,10 +278,13 @@ int CliHandler::handleInstall(const QStringList& args, PackageManager& pm) {
 int CliHandler::handleUninstall(const QStringList& args, PackageManager& pm) {
     QString packageId;
     QString source;
+    QString scope;
 
     for (int i = 0; i < args.size(); ++i) {
         if ((args[i] == QStringLiteral("-s") || args[i] == QStringLiteral("--source")) && i + 1 < args.size()) {
             source = args[++i];
+        } else if (args[i] == QStringLiteral("--scope") && i + 1 < args.size()) {
+            scope = args[++i];
         } else if (packageId.isEmpty()) {
             packageId = args[i];
         }
@@ -289,7 +292,7 @@ int CliHandler::handleUninstall(const QStringList& args, PackageManager& pm) {
 
     if (packageId.isEmpty()) {
         std::cerr << ANSI_RED "Error: Package ID required." ANSI_RESET "\n";
-        std::cout << "Usage: astra remove <package-id> [--source <source>]\n";
+        std::cout << "Usage: astra remove <package-id> [--source <source>] [--scope user|system]\n";
         return 1;
     }
 
@@ -309,7 +312,10 @@ int CliHandler::handleUninstall(const QStringList& args, PackageManager& pm) {
 
     std::cout << ANSI_BOLD "Uninstalling " ANSI_CYAN << packageId.toStdString() << ANSI_RESET "...\n";
 
-    bool ok = plugin->uninstall(packageId, {}, [](int pct, const QString& status) {
+    QVariantMap options;
+    if (!scope.isEmpty()) options[QStringLiteral("scope")] = scope;
+
+    bool ok = plugin->uninstall(packageId, options, [](int pct, const QString& status) {
         Q_UNUSED(pct);
         if (!status.isEmpty()) {
             std::cout << ANSI_DIM << "  " << status.toStdString() << ANSI_RESET << "\n";

--- a/src/cli/clihandler.cpp
+++ b/src/cli/clihandler.cpp
@@ -1,447 +1,525 @@
 #include "clihandler.hpp"
-#include <iostream>
-#include <iomanip>
-#include <QCoreApplication>
-#include <QFile>
 #include "marketplace/appimageinstaller.hpp"
 
-#define ANSI_RESET   "\033[0m"
-#define ANSI_BOLD    "\033[1m"
-#define ANSI_DIM     "\033[2m"
-#define ANSI_CYAN    "\033[36m"
-#define ANSI_GREEN   "\033[32m"
-#define ANSI_YELLOW  "\033[33m"
-#define ANSI_RED     "\033[31m"
-#define ANSI_MAGENTA "\033[35m"
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QVariantMap>
+#include <iomanip>
+#include <iostream>
+#include <unistd.h>
+
 #ifndef ASTRA_VERSION
 #define ASTRA_VERSION "1.1.0"
 #endif
 
+namespace {
+
+bool g_colours = true;
+
+const char* colour(const char* code) {
+    return g_colours ? code : "";
+}
+
+const char* reset() { return colour("\033[0m"); }
+const char* bold() { return colour("\033[1m"); }
+const char* dim() { return colour("\033[2m"); }
+const char* cyan() { return colour("\033[36m"); }
+const char* green() { return colour("\033[32m"); }
+const char* yellow() { return colour("\033[33m"); }
+const char* red() { return colour("\033[31m"); }
+const char* magenta() { return colour("\033[35m"); }
+
+const char* backendColour(const QString& backend) {
+    if (backend == QStringLiteral("Pacman")) return green();
+    if (backend == QStringLiteral("AUR")) return magenta();
+    if (backend == QStringLiteral("AppImage")) return yellow();
+    return cyan();
+}
+
+std::string text(const QString& value) {
+    return value.toStdString();
+}
+
+QString truncated(const QString& value, int width) {
+    return value.length() > width ? value.left(width - 3) + QStringLiteral("...") : value;
+}
+
+void printJson(const QJsonDocument& document) {
+    std::cout << document.toJson(QJsonDocument::Indented).toStdString();
+}
+
+QJsonArray toJsonArray(const QVariantList& items) {
+    QJsonArray array;
+    for (const QVariant& item : items) {
+        array.append(QJsonObject::fromVariantMap(item.toMap()));
+    }
+    return array;
+}
+
+void reportProgress(int percent, const QString& status) {
+    Q_UNUSED(percent);
+    if (!status.isEmpty()) {
+        std::cout << dim() << "  " << text(status) << reset() << "\n";
+    }
+}
+
+bool looksLikeAppImage(const QString& value) {
+    return value.endsWith(QLatin1String(".appimage"), Qt::CaseInsensitive) ||
+           (value.startsWith(QLatin1String("file://")) && value.contains(QLatin1String("appimage"), Qt::CaseInsensitive));
+}
+
+}
+
 void CliHandler::printVersion() {
-    std::cout << ANSI_BOLD ANSI_CYAN "astra" ANSI_RESET " version " ANSI_GREEN ASTRA_VERSION ANSI_RESET " (AstraMarket Universal Package Manager)\n";
+    std::cout << bold() << cyan() << "astra" << reset() << " version " << green() << ASTRA_VERSION << reset()
+              << " (AstraMarket Universal Package Manager)\n";
 }
 
 void CliHandler::printHelp() {
-    std::cout << ANSI_BOLD ANSI_CYAN "AstraMarket CLI" ANSI_RESET " - Unified Linux package management\n\n"
-              << ANSI_BOLD "USAGE:" ANSI_RESET "\n"
+    std::cout << bold() << cyan() << "AstraMarket CLI" << reset() << " - Unified Linux package management\n\n"
+              << bold() << "USAGE:" << reset() << "\n"
               << "  astra <COMMAND> [OPTIONS]\n\n"
-              << ANSI_BOLD "COMMANDS:" ANSI_RESET "\n"
-              << "  " ANSI_GREEN "search" ANSI_RESET " <query>          Search for packages across all or specific sources\n"
-              << "  " ANSI_GREEN "install" ANSI_RESET " <pkg>           Install a package\n"
-              << "  " ANSI_GREEN "remove" ANSI_RESET " <pkg>            Uninstall a package (alias: uninstall)\n"
-              << "  " ANSI_GREEN "list" ANSI_RESET "                  List installed packages\n"
-              << "  " ANSI_GREEN "update" ANSI_RESET "                Check for or perform updates (alias: upgrade)\n"
-              << "  " ANSI_GREEN "info" ANSI_RESET " <pkg>              Display metadata and details for a package\n"
-              << "  " ANSI_GREEN "sources" ANSI_RESET "               List registered package plugins & sources (alias: plugins)\n"
-              << "  " ANSI_GREEN "gui" ANSI_RESET "                   Launch the graphical interface (alias: --gui, -g)\n"
-              << "  " ANSI_GREEN "tray" ANSI_RESET "                  Launch minimized in system tray (alias: --tray, -t)\n\n"
-              << ANSI_BOLD "OPTIONS:" ANSI_RESET "\n"
-              << "  " ANSI_YELLOW "-s, --source" ANSI_RESET " <name>     Target specific package source (Flatpak, Pacman, AUR, AppImage, etc.)\n"
-              << "  " ANSI_YELLOW "--scope" ANSI_RESET " <user|system>    Specify installation scope (user or system, default: user for Flatpak)\n"
-              << "  " ANSI_YELLOW "-h, --help" ANSI_RESET "              Show this help message\n"
-              << "  " ANSI_YELLOW "-v, --version" ANSI_RESET "           Show version information\n\n"
-              << ANSI_BOLD "EXAMPLES:" ANSI_RESET "\n"
+              << bold() << "COMMANDS:" << reset() << "\n"
+              << "  " << green() << "search" << reset() << " <query>          Search for packages across all or specific sources\n"
+              << "  " << green() << "install" << reset() << " <pkg>           Install a package or a local .AppImage file\n"
+              << "  " << green() << "remove" << reset() << " <pkg>            Uninstall a package (alias: uninstall)\n"
+              << "  " << green() << "list" << reset() << "                    List installed packages\n"
+              << "  " << green() << "update" << reset() << "                  List available updates\n"
+              << "  " << green() << "upgrade" << reset() << " [pkg]           Apply updates, all of them or a single package\n"
+              << "  " << green() << "info" << reset() << " <pkg>              Display metadata and details for a package\n"
+              << "  " << green() << "sources" << reset() << "                 List registered package plugins & sources (alias: plugins)\n"
+              << "  " << green() << "gui" << reset() << "                     Launch the graphical interface (alias: --gui, -g)\n"
+              << "  " << green() << "tray" << reset() << "                    Launch minimized in system tray (alias: --tray, -t)\n\n"
+              << bold() << "OPTIONS:" << reset() << "\n"
+              << "  " << yellow() << "-s, --source" << reset() << " <name>     Target a specific package source (Flatpak, Pacman, AUR, AppImage, ...)\n"
+              << "  " << yellow() << "--scope" << reset() << " <user|system>   Installation scope, Flatpak only (default: where the package is)\n"
+              << "  " << yellow() << "--json" << reset() << "                  Print machine readable output\n"
+              << "  " << yellow() << "--no-color" << reset() << "              Disable coloured output (also honours NO_COLOR)\n"
+              << "  " << yellow() << "-h, --help" << reset() << "              Show this help message\n"
+              << "  " << yellow() << "-v, --version" << reset() << "           Show version information\n\n"
+              << bold() << "EXAMPLES:" << reset() << "\n"
               << "  astra search discord\n"
-              << "  astra search vlc --source Flatpak\n"
+              << "  astra search vlc --source Flatpak --json\n"
               << "  astra install org.videolan.VLC --scope system\n"
-              << "  astra info com.spotify.Client\n"
-              << "  astra sources\n";
+              << "  astra install yay-bin --source AUR\n"
+              << "  astra upgrade\n"
+              << "  astra info com.spotify.Client\n\n"
+              << bold() << "EXIT STATUS:" << reset() << "\n"
+              << "  0  success\n"
+              << "  1  the requested operation failed or the arguments were invalid\n";
 }
 
-int CliHandler::run(int argc, char* argv[], PackageManager& pm) {
-    if (argc < 2) {
-        printHelp();
+CliHandler::Options CliHandler::parseOptions(const QStringList& args) {
+    Options options;
+
+    for (int i = 0; i < args.size(); ++i) {
+        const QString& argument = args.at(i);
+
+        if ((argument == QStringLiteral("-s") || argument == QStringLiteral("--source")) && i + 1 < args.size()) {
+            options.source = args.at(++i);
+        } else if (argument == QStringLiteral("--scope") && i + 1 < args.size()) {
+            options.scope = args.at(++i);
+        } else if (argument == QStringLiteral("--json")) {
+            options.json = true;
+        } else if (argument == QStringLiteral("--no-color") || argument == QStringLiteral("--no-colour")) {
+            continue;
+        } else {
+            options.positional.append(argument);
+        }
+    }
+
+    return options;
+}
+
+IPackagePlugin* CliHandler::resolveSource(const QString& packageId, const Options& options, PackageManager& pm, bool installedOnly, bool requireUnique) {
+    if (!options.source.isEmpty()) {
+        IPackagePlugin* plugin = pm.findPlugin(options.source);
+        if (!plugin) {
+            std::cerr << red() << "Error: source \"" << text(options.source) << "\" not found." << reset() << "\n";
+        }
+        return plugin;
+    }
+
+    QList<IPackagePlugin*> candidates;
+    for (IPackagePlugin* plugin : pm.plugins()) {
+        if (!plugin->isAvailable() || !plugin->isEnabled()) continue;
+
+        if (installedOnly) {
+            if (pm.isPackageInstalled(plugin->id(), packageId)) candidates.append(plugin);
+            continue;
+        }
+
+        const QVariantList results = plugin->search(packageId);
+        for (const QVariant& value : results) {
+            if (value.toMap().value(QStringLiteral("id")).toString().compare(packageId, Qt::CaseInsensitive) == 0) {
+                candidates.append(plugin);
+                break;
+            }
+        }
+    }
+
+    if (candidates.size() == 1) return candidates.first();
+
+    if (candidates.size() > 1) {
+        if (!requireUnique) {
+            std::cout << dim() << "Using " << text(candidates.first()->name()) << ", also available from ";
+            for (int i = 1; i < candidates.size(); ++i) {
+                if (i > 1) std::cout << ", ";
+                std::cout << text(candidates.at(i)->name());
+            }
+            std::cout << " (--source picks another)" << reset() << "\n";
+            return candidates.first();
+        }
+
+        std::cerr << yellow() << "\"" << text(packageId) << "\" is available from several sources:" << reset() << "\n";
+        for (IPackagePlugin* plugin : candidates) {
+            std::cerr << "  " << backendColour(plugin->id()) << text(plugin->name()) << reset() << "\n";
+        }
+        std::cerr << "Pick one with " << bold() << "--source <name>" << reset() << ".\n";
+        return nullptr;
+    }
+
+    if (installedOnly) {
+        std::cerr << red() << "Error: \"" << text(packageId) << "\" is not installed." << reset() << "\n";
+        return nullptr;
+    }
+
+    IPackagePlugin* fallback = pm.findPlugin(packageId.contains(QLatin1Char('.')) ? QStringLiteral("Flatpak") : QStringLiteral("Pacman"));
+    if (!fallback) {
+        std::cerr << red() << "Error: no source provides \"" << text(packageId) << "\"." << reset() << "\n";
+    }
+    return fallback;
+}
+
+int CliHandler::installAppImageFile(const QString& path) {
+    AppImageInstaller installer;
+    std::cout << bold() << "Installing AppImage: " << cyan() << text(path) << reset() << "...\n";
+
+    if (installer.installAppImage(path)) {
+        std::cout << green() << bold() << "Successfully installed AppImage" << reset() << "\n";
+        std::cout << dim() << "  Desktop entry registered in ~/.local/share/applications" << reset() << "\n";
         return 0;
     }
 
+    std::cerr << red() << bold() << "Failed to install AppImage: " << text(installer.statusMessage()) << reset() << "\n";
+    return 1;
+}
+
+int CliHandler::run(int argc, char* argv[], PackageManager& pm) {
     QStringList args;
     for (int i = 1; i < argc; ++i) {
         args.append(QString::fromUtf8(argv[i]));
     }
 
-    QString cmd = args.first().toLower();
-    args.removeFirst();
+    g_colours = isatty(STDOUT_FILENO) && !qEnvironmentVariableIsSet("NO_COLOR") &&
+                !args.contains(QStringLiteral("--no-color")) && !args.contains(QStringLiteral("--no-colour"));
 
-    if (cmd == QStringLiteral("--help") || cmd == QStringLiteral("-h") || cmd == QStringLiteral("help")) {
+    if (args.isEmpty()) {
         printHelp();
         return 0;
     }
-    if (cmd == QStringLiteral("--version") || cmd == QStringLiteral("-v") || cmd == QStringLiteral("version")) {
+
+    const QString command = args.takeFirst().toLower();
+    const Options options = parseOptions(args);
+
+    if (command == QStringLiteral("--help") || command == QStringLiteral("-h") || command == QStringLiteral("help")) {
+        printHelp();
+        return 0;
+    }
+    if (command == QStringLiteral("--version") || command == QStringLiteral("-v") || command == QStringLiteral("version")) {
         printVersion();
         return 0;
     }
-    if (cmd == QStringLiteral("search")) {
-        return handleSearch(args, pm);
-    }
-    if (cmd == QStringLiteral("install")) {
-        return handleInstall(args, pm);
-    }
-    if (cmd == QStringLiteral("remove") || cmd == QStringLiteral("uninstall")) {
-        return handleUninstall(args, pm);
-    }
-    if (cmd == QStringLiteral("list") || cmd == QStringLiteral("installed")) {
-        return handleList(args, pm);
-    }
-    if (cmd == QStringLiteral("update") || cmd == QStringLiteral("upgrade")) {
-        return handleUpdate(args, pm);
-    }
-    if (cmd == QStringLiteral("info")) {
-        return handleInfo(args, pm);
-    }
-    if (cmd == QStringLiteral("sources") || cmd == QStringLiteral("plugins")) {
-        return handleSources(args, pm);
+    if (command == QStringLiteral("search")) return handleSearch(options, pm);
+    if (command == QStringLiteral("install")) return handleInstall(options, pm);
+    if (command == QStringLiteral("remove") || command == QStringLiteral("uninstall")) return handleUninstall(options, pm);
+    if (command == QStringLiteral("list") || command == QStringLiteral("installed")) return handleList(options, pm);
+    if (command == QStringLiteral("update")) return handleUpdate(options, pm);
+    if (command == QStringLiteral("upgrade")) return handleUpgrade(options, pm);
+    if (command == QStringLiteral("info")) return handleInfo(options, pm);
+    if (command == QStringLiteral("sources") || command == QStringLiteral("plugins")) return handleSources(options, pm);
+
+    if (looksLikeAppImage(command) || QFile::exists(command)) {
+        return installAppImageFile(command);
     }
 
-    if (cmd.endsWith(QLatin1String(".appimage"), Qt::CaseInsensitive) ||
-        cmd.startsWith(QLatin1String("file://")) ||
-        QFile::exists(cmd)) {
-        AppImageInstaller installer;
-        std::cout << ANSI_BOLD "Installing AppImage: " ANSI_CYAN << cmd.toStdString() << ANSI_RESET "...\n";
-        bool ok = installer.installAppImage(cmd);
-        if (ok) {
-            std::cout << ANSI_GREEN ANSI_BOLD "✓ Successfully installed AppImage!" ANSI_RESET "\n";
-            std::cout << ANSI_DIM "  Desktop entry registered in ~/.local/share/applications" ANSI_RESET "\n";
-            return 0;
-        } else {
-            std::cerr << ANSI_RED ANSI_BOLD "✗ Failed to install AppImage: " << installer.statusMessage().toStdString() << ANSI_RESET "\n";
-            return 1;
-        }
-    }
-
-    std::cerr << ANSI_RED "Unknown command: " << cmd.toStdString() << ANSI_RESET "\n";
-    std::cout << "Run " ANSI_BOLD "astra --help" ANSI_RESET " for available commands.\n";
+    std::cerr << red() << "Unknown command: " << text(command) << reset() << "\n";
+    std::cout << "Run " << bold() << "astra --help" << reset() << " for available commands.\n";
     return 1;
 }
 
-int CliHandler::handleSources(const QStringList& args, PackageManager& pm) {
-    Q_UNUSED(args);
-    std::cout << ANSI_BOLD ANSI_CYAN "Registered Package Sources & Plugins:" ANSI_RESET "\n\n";
+int CliHandler::handleSources(const Options& options, PackageManager& pm) {
+    const QVariantList plugins = pm.getRegisteredPluginsInfo();
 
-    QVariantList plugins = pm.getRegisteredPluginsInfo();
-    for (const QVariant& p : plugins) {
-        QVariantMap map = p.toMap();
-        QString name = map.value(QStringLiteral("name")).toString();
-        QString desc = map.value(QStringLiteral("description")).toString();
-        bool isAvail = map.value(QStringLiteral("isAvailable")).toBool();
-        bool isEnabled = map.value(QStringLiteral("isEnabled")).toBool();
-
-        std::cout << "  • " << ANSI_BOLD << name.toStdString() << ANSI_RESET;
-        if (isAvail && isEnabled) {
-            std::cout << " [" ANSI_GREEN "active" ANSI_RESET "]";
-        } else if (!isAvail) {
-            std::cout << " [" ANSI_RED "unavailable" ANSI_RESET "]";
-        } else {
-            std::cout << " [" ANSI_YELLOW "disabled" ANSI_RESET "]";
-        }
-        std::cout << "\n    " << ANSI_DIM << desc.toStdString() << ANSI_RESET "\n\n";
-    }
-    return 0;
-}
-
-int CliHandler::handleSearch(const QStringList& args, PackageManager& pm) {
-    QString query;
-    QString source;
-
-    for (int i = 0; i < args.size(); ++i) {
-        if ((args[i] == QStringLiteral("-s") || args[i] == QStringLiteral("--source")) && i + 1 < args.size()) {
-            source = args[++i];
-        } else if (query.isEmpty()) {
-            query = args[i];
-        }
-    }
-
-    if (query.isEmpty()) {
-        std::cerr << ANSI_RED "Error: Search query required." ANSI_RESET "\n";
-        std::cout << "Usage: astra search <query> [--source <source>]\n";
-        return 1;
-    }
-
-    std::cout << ANSI_DIM "Searching for \"" << query.toStdString() << "\"..." ANSI_RESET "\n\n";
-
-    QVariantList results = pm.searchPackages(query, source);
-    if (results.isEmpty()) {
-        std::cout << ANSI_YELLOW "No packages found matching \"" << query.toStdString() << "\"." ANSI_RESET "\n";
+    if (options.json) {
+        printJson(QJsonDocument(toJsonArray(plugins)));
         return 0;
     }
 
-    std::cout << ANSI_BOLD
-              << std::left << std::setw(36) << "PACKAGE ID"
-              << std::setw(12) << "SOURCE"
-              << std::setw(24) << "NAME"
-              << "SUMMARY"
-              << ANSI_RESET "\n";
+    std::cout << bold() << cyan() << "Registered Package Sources & Plugins:" << reset() << "\n\n";
+    for (const QVariant& value : plugins) {
+        const QVariantMap plugin = value.toMap();
+        const bool available = plugin.value(QStringLiteral("isAvailable")).toBool();
+        const bool enabled = plugin.value(QStringLiteral("isEnabled")).toBool();
 
-    std::cout << std::string(90, '-') << "\n";
-
-    for (const QVariant& v : results) {
-        QVariantMap map = v.toMap();
-        QString id = map.value(QStringLiteral("id")).toString();
-        QString backend = map.value(QStringLiteral("backend")).toString();
-        QString name = map.value(QStringLiteral("name")).toString();
-        QString summary = map.value(QStringLiteral("summary")).toString();
-
-        if (id.length() > 34) id = id.left(31) + QStringLiteral("...");
-        if (name.length() > 22) name = name.left(19) + QStringLiteral("...");
-        if (summary.length() > 40) summary = summary.left(37) + QStringLiteral("...");
-
-        std::string backendColor = ANSI_CYAN;
-        if (backend == QStringLiteral("Pacman")) backendColor = ANSI_GREEN;
-        else if (backend == QStringLiteral("AUR")) backendColor = ANSI_MAGENTA;
-        else if (backend == QStringLiteral("AppImage")) backendColor = ANSI_YELLOW;
-
-        std::cout << std::left << std::setw(36) << id.toStdString()
-                  << backendColor << std::setw(12) << backend.toStdString() << ANSI_RESET
-                  << std::setw(24) << name.toStdString()
-                  << ANSI_DIM << summary.toStdString() << ANSI_RESET
-                  << "\n";
+        std::cout << "  - " << bold() << text(plugin.value(QStringLiteral("name")).toString()) << reset();
+        if (available && enabled) {
+            std::cout << " [" << green() << "active" << reset() << "]";
+        } else if (!available) {
+            std::cout << " [" << red() << "unavailable" << reset() << "]";
+        } else {
+            std::cout << " [" << yellow() << "disabled" << reset() << "]";
+        }
+        std::cout << "\n    " << dim() << text(plugin.value(QStringLiteral("description")).toString()) << reset() << "\n\n";
     }
-
-    std::cout << "\nFound " ANSI_GREEN << results.size() << ANSI_RESET " packages.\n";
     return 0;
 }
 
-int CliHandler::handleInstall(const QStringList& args, PackageManager& pm) {
-    QString packageId;
-    QString source;
-    QString scope = QStringLiteral("user");
-
-    for (int i = 0; i < args.size(); ++i) {
-        if ((args[i] == QStringLiteral("-s") || args[i] == QStringLiteral("--source")) && i + 1 < args.size()) {
-            source = args[++i];
-        } else if (args[i] == QStringLiteral("--scope") && i + 1 < args.size()) {
-            scope = args[++i];
-        } else if (packageId.isEmpty()) {
-            packageId = args[i];
-        }
+int CliHandler::handleSearch(const Options& options, PackageManager& pm) {
+    const QString query = options.positional.value(0);
+    if (query.isEmpty()) {
+        std::cerr << red() << "Error: search query required." << reset() << "\n";
+        std::cout << "Usage: astra search <query> [--source <source>] [--json]\n";
+        return 1;
     }
 
+    const QVariantList results = pm.searchPackages(query, options.source);
+
+    if (options.json) {
+        printJson(QJsonDocument(toJsonArray(results)));
+        return 0;
+    }
+
+    std::cout << dim() << "Searching for \"" << text(query) << "\"..." << reset() << "\n\n";
+    if (results.isEmpty()) {
+        std::cout << yellow() << "No packages found matching \"" << text(query) << "\"." << reset() << "\n";
+        return 0;
+    }
+
+    std::cout << bold() << std::left << std::setw(36) << "PACKAGE ID" << std::setw(12) << "SOURCE" << std::setw(24) << "NAME"
+              << "SUMMARY" << reset() << "\n";
+    std::cout << std::string(90, '-') << "\n";
+
+    for (const QVariant& value : results) {
+        const QVariantMap item = value.toMap();
+        const QString backend = item.value(QStringLiteral("backend")).toString();
+
+        std::cout << std::left << std::setw(36) << text(truncated(item.value(QStringLiteral("id")).toString(), 34))
+                  << backendColour(backend) << std::setw(12) << text(backend) << reset()
+                  << std::setw(24) << text(truncated(item.value(QStringLiteral("name")).toString(), 22))
+                  << dim() << text(truncated(item.value(QStringLiteral("summary")).toString(), 40)) << reset() << "\n";
+    }
+
+    std::cout << "\nFound " << green() << results.size() << reset() << " packages.\n";
+    return 0;
+}
+
+int CliHandler::handleInstall(const Options& options, PackageManager& pm) {
+    const QString packageId = options.positional.value(0);
     if (packageId.isEmpty()) {
-        std::cerr << ANSI_RED "Error: Package ID required." ANSI_RESET "\n";
+        std::cerr << red() << "Error: package id required." << reset() << "\n";
         std::cout << "Usage: astra install <package-id> [--source <source>] [--scope user|system]\n";
         return 1;
     }
 
-    if (packageId.endsWith(QLatin1String(".AppImage"), Qt::CaseInsensitive) ||
-        packageId.endsWith(QLatin1String(".appimage"), Qt::CaseInsensitive) ||
-        packageId.startsWith(QLatin1String("file://")) ||
-        (QFile::exists(packageId) && source == QStringLiteral("AppImage"))) {
-        AppImageInstaller installer;
-        std::cout << ANSI_BOLD "Installing AppImage: " ANSI_CYAN << packageId.toStdString() << ANSI_RESET "...\n";
-        bool ok = installer.installAppImage(packageId);
-        if (ok) {
-            std::cout << ANSI_GREEN ANSI_BOLD "✓ Successfully installed AppImage: " << packageId.toStdString() << ANSI_RESET "\n";
-            std::cout << ANSI_DIM "  Desktop entry registered in ~/.local/share/applications" ANSI_RESET "\n";
-            return 0;
-        } else {
-            std::cerr << ANSI_RED ANSI_BOLD "✗ Failed to install AppImage: " << installer.statusMessage().toStdString() << ANSI_RESET "\n";
-            return 1;
-        }
+    if (looksLikeAppImage(packageId) || (QFile::exists(packageId) && options.source.compare(QStringLiteral("AppImage"), Qt::CaseInsensitive) == 0)) {
+        return installAppImageFile(packageId);
     }
 
-    if (source.isEmpty()) {
-        if (packageId.contains(QLatin1Char('.'))) {
-            source = QStringLiteral("Flatpak");
-        } else {
-            source = QStringLiteral("Pacman");
-        }
-    }
+    IPackagePlugin* plugin = resolveSource(packageId, options, pm, false, true);
+    if (!plugin) return 1;
 
-    IPackagePlugin* plugin = pm.findPlugin(source);
-    if (!plugin) {
-        std::cerr << ANSI_RED "Error: Source plugin \"" << source.toStdString() << "\" not found." ANSI_RESET "\n";
-        return 1;
-    }
+    std::cout << bold() << "Installing " << cyan() << text(packageId) << reset() << " from " << green() << text(plugin->name()) << reset();
+    if (!options.scope.isEmpty()) std::cout << " (scope: " << text(options.scope) << ")";
+    std::cout << "...\n";
 
-    std::cout << ANSI_BOLD "Installing " ANSI_CYAN << packageId.toStdString() << ANSI_RESET
-              << " from " ANSI_GREEN << plugin->name().toStdString() << ANSI_RESET
-              << " (scope: " << scope.toStdString() << ")...\n";
+    QVariantMap pluginOptions;
+    if (!options.scope.isEmpty()) pluginOptions[QStringLiteral("scope")] = options.scope;
 
-    QVariantMap options;
-    options[QStringLiteral("scope")] = scope;
-
-    bool ok = plugin->install(packageId, options, [](int pct, const QString& status) {
-        Q_UNUSED(pct);
-        if (!status.isEmpty()) {
-            std::cout << ANSI_DIM << "  " << status.toStdString() << ANSI_RESET << "\n";
-        }
-    });
-
-    if (ok) {
-        std::cout << ANSI_GREEN ANSI_BOLD "✓ Successfully installed " << packageId.toStdString() << ANSI_RESET "\n";
+    if (plugin->install(packageId, pluginOptions, reportProgress)) {
+        std::cout << green() << bold() << "Successfully installed " << text(packageId) << reset() << "\n";
         return 0;
-    } else {
-        std::cerr << ANSI_RED ANSI_BOLD "✗ Failed to install " << packageId.toStdString() << ANSI_RESET "\n";
-        return 1;
     }
+
+    std::cerr << red() << bold() << "Failed to install " << text(packageId) << reset() << "\n";
+    return 1;
 }
 
-int CliHandler::handleUninstall(const QStringList& args, PackageManager& pm) {
-    QString packageId;
-    QString source;
-    QString scope;
-
-    for (int i = 0; i < args.size(); ++i) {
-        if ((args[i] == QStringLiteral("-s") || args[i] == QStringLiteral("--source")) && i + 1 < args.size()) {
-            source = args[++i];
-        } else if (args[i] == QStringLiteral("--scope") && i + 1 < args.size()) {
-            scope = args[++i];
-        } else if (packageId.isEmpty()) {
-            packageId = args[i];
-        }
-    }
-
+int CliHandler::handleUninstall(const Options& options, PackageManager& pm) {
+    const QString packageId = options.positional.value(0);
     if (packageId.isEmpty()) {
-        std::cerr << ANSI_RED "Error: Package ID required." ANSI_RESET "\n";
+        std::cerr << red() << "Error: package id required." << reset() << "\n";
         std::cout << "Usage: astra remove <package-id> [--source <source>] [--scope user|system]\n";
         return 1;
     }
 
-    if (source.isEmpty()) {
-        if (packageId.contains(QLatin1Char('.'))) {
-            source = QStringLiteral("Flatpak");
-        } else {
-            source = QStringLiteral("Pacman");
-        }
-    }
+    IPackagePlugin* plugin = resolveSource(packageId, options, pm, true, true);
+    if (!plugin) return 1;
 
-    IPackagePlugin* plugin = pm.findPlugin(source);
-    if (!plugin) {
-        std::cerr << ANSI_RED "Error: Source plugin \"" << source.toStdString() << "\" not found." ANSI_RESET "\n";
-        return 1;
-    }
+    std::cout << bold() << "Uninstalling " << cyan() << text(packageId) << reset() << " (" << text(plugin->name()) << ")...\n";
 
-    std::cout << ANSI_BOLD "Uninstalling " ANSI_CYAN << packageId.toStdString() << ANSI_RESET "...\n";
+    QVariantMap pluginOptions;
+    if (!options.scope.isEmpty()) pluginOptions[QStringLiteral("scope")] = options.scope;
 
-    QVariantMap options;
-    if (!scope.isEmpty()) options[QStringLiteral("scope")] = scope;
-
-    bool ok = plugin->uninstall(packageId, options, [](int pct, const QString& status) {
-        Q_UNUSED(pct);
-        if (!status.isEmpty()) {
-            std::cout << ANSI_DIM << "  " << status.toStdString() << ANSI_RESET << "\n";
-        }
-    });
-
-    if (ok) {
-        std::cout << ANSI_GREEN ANSI_BOLD "✓ Successfully removed " << packageId.toStdString() << ANSI_RESET "\n";
+    if (plugin->uninstall(packageId, pluginOptions, reportProgress)) {
+        std::cout << green() << bold() << "Successfully removed " << text(packageId) << reset() << "\n";
         return 0;
-    } else {
-        std::cerr << ANSI_RED ANSI_BOLD "✗ Failed to remove " << packageId.toStdString() << ANSI_RESET "\n";
-        return 1;
     }
+
+    std::cerr << red() << bold() << "Failed to remove " << text(packageId) << reset() << "\n";
+    return 1;
 }
 
-int CliHandler::handleList(const QStringList& args, PackageManager& pm) {
-    Q_UNUSED(args);
-    std::cout << ANSI_DIM "Listing installed packages..." ANSI_RESET "\n\n";
-
+int CliHandler::handleList(const Options& options, PackageManager& pm) {
     QVariantList installed = pm.getInstalledPackages();
+
+    if (!options.source.isEmpty()) {
+        QVariantList filtered;
+        for (const QVariant& value : installed) {
+            if (value.toMap().value(QStringLiteral("backend")).toString().compare(options.source, Qt::CaseInsensitive) == 0) {
+                filtered.append(value);
+            }
+        }
+        installed = filtered;
+    }
+
+    if (options.json) {
+        printJson(QJsonDocument(toJsonArray(installed)));
+        return 0;
+    }
+
+    std::cout << dim() << "Listing installed packages..." << reset() << "\n\n";
     if (installed.isEmpty()) {
         std::cout << "No installed packages found.\n";
         return 0;
     }
 
-    std::cout << ANSI_BOLD
-              << std::left << std::setw(36) << "PACKAGE ID"
-              << std::setw(12) << "SOURCE"
-              << std::setw(18) << "VERSION"
-              << "SCOPE"
-              << ANSI_RESET "\n";
+    std::cout << bold() << std::left << std::setw(36) << "PACKAGE ID" << std::setw(12) << "SOURCE" << std::setw(18) << "VERSION"
+              << "SCOPE" << reset() << "\n";
     std::cout << std::string(75, '-') << "\n";
 
-    for (const QVariant& v : installed) {
-        QVariantMap map = v.toMap();
-        QString id = map.value(QStringLiteral("id")).toString();
-        QString backend = map.value(QStringLiteral("backend")).toString();
-        QString version = map.value(QStringLiteral("version")).toString();
-        QString scope = map.value(QStringLiteral("scope")).toString();
-
-        if (id.length() > 34) id = id.left(31) + QStringLiteral("...");
-        if (version.length() > 16) version = version.left(13) + QStringLiteral("...");
-
-        std::cout << std::left << std::setw(36) << id.toStdString()
-                  << std::setw(12) << backend.toStdString()
-                  << std::setw(18) << version.toStdString()
-                  << ANSI_DIM << scope.toStdString() << ANSI_RESET
-                  << "\n";
+    for (const QVariant& value : installed) {
+        const QVariantMap item = value.toMap();
+        std::cout << std::left << std::setw(36) << text(truncated(item.value(QStringLiteral("id")).toString(), 34))
+                  << std::setw(12) << text(item.value(QStringLiteral("backend")).toString())
+                  << std::setw(18) << text(truncated(item.value(QStringLiteral("version")).toString(), 16))
+                  << dim() << text(item.value(QStringLiteral("scope")).toString()) << reset() << "\n";
     }
 
-    std::cout << "\nTotal installed: " ANSI_GREEN << installed.size() << ANSI_RESET "\n";
+    std::cout << "\nTotal installed: " << green() << installed.size() << reset() << "\n";
     return 0;
 }
 
-int CliHandler::handleUpdate(const QStringList& args, PackageManager& pm) {
-    Q_UNUSED(args);
-    std::cout << ANSI_DIM "Checking for updates across all sources..." ANSI_RESET "\n\n";
+int CliHandler::handleUpdate(const Options& options, PackageManager& pm) {
+    const QVariantList updates = pm.checkForUpdates();
 
-    QVariantList updates = pm.checkForUpdates();
-    if (updates.isEmpty()) {
-        std::cout << ANSI_GREEN "✓ All packages are up to date." ANSI_RESET "\n";
+    if (options.json) {
+        printJson(QJsonDocument(toJsonArray(updates)));
         return 0;
     }
 
-    std::cout << ANSI_BOLD "Available Updates (" << updates.size() << "):" ANSI_RESET "\n";
-    for (const QVariant& v : updates) {
-        QVariantMap map = v.toMap();
-        std::cout << "  • " << map.value(QStringLiteral("name")).toString().toStdString()
-                  << " [" << map.value(QStringLiteral("backend")).toString().toStdString() << "] "
-                  << ANSI_YELLOW << map.value(QStringLiteral("version")).toString().toStdString() << ANSI_RESET "\n";
+    std::cout << dim() << "Checking for updates across all sources..." << reset() << "\n\n";
+    if (updates.isEmpty()) {
+        std::cout << green() << "All packages are up to date." << reset() << "\n";
+        return 0;
     }
 
+    std::cout << bold() << "Available Updates (" << updates.size() << "):" << reset() << "\n";
+    for (const QVariant& value : updates) {
+        const QVariantMap item = value.toMap();
+        std::cout << "  - " << text(item.value(QStringLiteral("name")).toString()) << " ["
+                  << text(item.value(QStringLiteral("backend")).toString()) << "] " << yellow()
+                  << text(item.value(QStringLiteral("version")).toString()) << reset() << "\n";
+    }
+    std::cout << "\nApply them with " << bold() << "astra upgrade" << reset() << ".\n";
     return 0;
 }
 
-int CliHandler::handleInfo(const QStringList& args, PackageManager& pm) {
-    QString packageId;
-    QString source;
-
-    for (int i = 0; i < args.size(); ++i) {
-        if ((args[i] == QStringLiteral("-s") || args[i] == QStringLiteral("--source")) && i + 1 < args.size()) {
-            source = args[++i];
-        } else if (packageId.isEmpty()) {
-            packageId = args[i];
-        }
-    }
+int CliHandler::handleUpgrade(const Options& options, PackageManager& pm) {
+    const QString packageId = options.positional.value(0);
 
     if (packageId.isEmpty()) {
-        std::cerr << ANSI_RED "Error: Package ID required." ANSI_RESET "\n";
-        std::cout << "Usage: astra info <package-id> [--source <source>]\n";
+        std::cout << bold() << "Applying updates..." << reset() << "\n";
+        const bool success = pm.runSystemUpdate([](const QString& line) {
+            std::cout << dim() << "  " << text(line) << reset() << "\n";
+        });
+
+        if (success) {
+            std::cout << green() << bold() << "Updates applied" << reset() << "\n";
+            return 0;
+        }
+        std::cerr << red() << bold() << "Some updates could not be applied" << reset() << "\n";
         return 1;
     }
 
-    if (source.isEmpty()) {
-        if (packageId.contains(QLatin1Char('.'))) {
-            source = QStringLiteral("Flatpak");
-        } else {
-            source = QStringLiteral("Pacman");
-        }
+    IPackagePlugin* plugin = resolveSource(packageId, options, pm, true, true);
+    if (!plugin) return 1;
+
+    std::cout << bold() << "Updating " << cyan() << text(packageId) << reset() << " (" << text(plugin->name()) << ")...\n";
+
+    QVariantMap pluginOptions;
+    if (!options.scope.isEmpty()) pluginOptions[QStringLiteral("scope")] = options.scope;
+
+    if (plugin->update(packageId, pluginOptions, reportProgress)) {
+        std::cout << green() << bold() << "Successfully updated " << text(packageId) << reset() << "\n";
+        return 0;
     }
 
-    QVariantMap details = pm.getPackageDetails(packageId, source);
-    std::cout << ANSI_BOLD ANSI_CYAN << (details.value(QStringLiteral("name")).toString().isEmpty() ? packageId.toStdString() : details.value(QStringLiteral("name")).toString().toStdString()) << ANSI_RESET "\n";
+    std::cerr << red() << bold() << "Failed to update " << text(packageId) << reset() << "\n";
+    return 1;
+}
+
+int CliHandler::handleInfo(const Options& options, PackageManager& pm) {
+    const QString packageId = options.positional.value(0);
+    if (packageId.isEmpty()) {
+        std::cerr << red() << "Error: package id required." << reset() << "\n";
+        std::cout << "Usage: astra info <package-id> [--source <source>] [--json]\n";
+        return 1;
+    }
+
+    IPackagePlugin* plugin = resolveSource(packageId, options, pm, false, false);
+    if (!plugin) return 1;
+
+    const QVariantMap details = plugin->getDetails(packageId);
+
+    if (options.json) {
+        printJson(QJsonDocument(QJsonObject::fromVariantMap(details)));
+        return 0;
+    }
+
+    const QString name = details.value(QStringLiteral("name")).toString();
+    std::cout << bold() << cyan() << text(name.isEmpty() ? packageId : name) << reset() << "\n";
     std::cout << std::string(50, '=') << "\n";
-    std::cout << ANSI_BOLD "ID:          " ANSI_RESET << details.value(QStringLiteral("id")).toString().toStdString() << "\n";
-    std::cout << ANSI_BOLD "Backend:     " ANSI_RESET << details.value(QStringLiteral("backend")).toString().toStdString() << "\n";
-    if (!details.value(QStringLiteral("version")).toString().isEmpty())
-        std::cout << ANSI_BOLD "Version:     " ANSI_RESET << details.value(QStringLiteral("version")).toString().toStdString() << "\n";
-    if (!details.value(QStringLiteral("developer")).toString().isEmpty())
-        std::cout << ANSI_BOLD "Developer:   " ANSI_RESET << details.value(QStringLiteral("developer")).toString().toStdString() << "\n";
-    if (!details.value(QStringLiteral("license")).toString().isEmpty())
-        std::cout << ANSI_BOLD "License:     " ANSI_RESET << details.value(QStringLiteral("license")).toString().toStdString() << "\n";
-    if (!details.value(QStringLiteral("homepage")).toString().isEmpty())
-        std::cout << ANSI_BOLD "Homepage:    " ANSI_RESET << details.value(QStringLiteral("homepage")).toString().toStdString() << "\n";
-    if (!details.value(QStringLiteral("summary")).toString().isEmpty())
-        std::cout << ANSI_BOLD "Summary:     " ANSI_RESET << details.value(QStringLiteral("summary")).toString().toStdString() << "\n";
-    if (!details.value(QStringLiteral("description")).toString().isEmpty()) {
-        std::cout << "\n" ANSI_BOLD "Description:" ANSI_RESET "\n" << details.value(QStringLiteral("description")).toString().toStdString() << "\n";
+
+    const auto field = [&details](const char* label, const QString& key) {
+        const QString value = details.value(key).toString();
+        if (value.isEmpty()) return;
+        std::cout << bold() << label << reset() << text(value) << "\n";
+    };
+
+    field("ID:          ", QStringLiteral("id"));
+    field("Backend:     ", QStringLiteral("backend"));
+    field("Version:     ", QStringLiteral("version"));
+    field("Repository:  ", QStringLiteral("repository"));
+    field("Developer:   ", QStringLiteral("developer"));
+    field("License:     ", QStringLiteral("license"));
+    field("Size:        ", QStringLiteral("installedSize"));
+    field("Homepage:    ", QStringLiteral("homepage"));
+    field("Summary:     ", QStringLiteral("summary"));
+
+    const QString description = details.value(QStringLiteral("description")).toString();
+    if (!description.isEmpty()) {
+        std::cout << "\n" << bold() << "Description:" << reset() << "\n" << text(description) << "\n";
     }
 
-    QList<QVariantMap> sources = pm.getInstallSources(source, packageId);
+    const QList<QVariantMap> sources = pm.getInstallSources(plugin->id(), packageId);
     if (!sources.isEmpty()) {
-        std::cout << "\n" ANSI_BOLD "Available Installation Scopes:" ANSI_RESET "\n";
-        for (const auto& s : sources) {
-            std::cout << "  • " << s.value(QStringLiteral("label")).toString().toStdString()
-                      << " (--scope " << s.value(QStringLiteral("id")).toString().toStdString() << ")\n";
+        std::cout << "\n" << bold() << "Available Installation Scopes:" << reset() << "\n";
+        for (const QVariantMap& source : sources) {
+            std::cout << "  - " << text(source.value(QStringLiteral("label")).toString()) << " (--scope "
+                      << text(source.value(QStringLiteral("id")).toString()) << ")\n";
         }
     }
     return 0;

--- a/src/cli/clihandler.hpp
+++ b/src/cli/clihandler.hpp
@@ -8,13 +8,25 @@ public:
     static int run(int argc, char* argv[], PackageManager& pm);
 
 private:
+    struct Options {
+        QString source;
+        QString scope;
+        bool json{false};
+        QStringList positional;
+    };
+
+    static Options parseOptions(const QStringList& args);
+    static IPackagePlugin* resolveSource(const QString& packageId, const Options& options, PackageManager& pm, bool installedOnly, bool requireUnique);
+
     static void printHelp();
     static void printVersion();
-    static int handleSearch(const QStringList& args, PackageManager& pm);
-    static int handleInstall(const QStringList& args, PackageManager& pm);
-    static int handleUninstall(const QStringList& args, PackageManager& pm);
-    static int handleList(const QStringList& args, PackageManager& pm);
-    static int handleUpdate(const QStringList& args, PackageManager& pm);
-    static int handleInfo(const QStringList& args, PackageManager& pm);
-    static int handleSources(const QStringList& args, PackageManager& pm);
+    static int handleSearch(const Options& options, PackageManager& pm);
+    static int handleInstall(const Options& options, PackageManager& pm);
+    static int handleUninstall(const Options& options, PackageManager& pm);
+    static int handleList(const Options& options, PackageManager& pm);
+    static int handleUpdate(const Options& options, PackageManager& pm);
+    static int handleUpgrade(const Options& options, PackageManager& pm);
+    static int handleInfo(const Options& options, PackageManager& pm);
+    static int handleSources(const Options& options, PackageManager& pm);
+    static int installAppImageFile(const QString& path);
 };

--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -1,4 +1,5 @@
 #include "packagemanager.hpp"
+#include "pluginprocess.hpp"
 #include <QFutureWatcher>
 #include <QtConcurrent>
 #include <QDir>
@@ -560,73 +561,19 @@ void PackageManager::updateAllPackages() {
     const bool useCaelestia = useCaelestiaUpdate();
 
     QFuture<bool> future = QtConcurrent::run([this, useCaelestia] {
-        // Flatpak updates
-        if (enableFlatpak() && QFile::exists(QStringLiteral("/usr/bin/flatpak"))) {
+        const auto logLine = [this](const QString& line) { appendLog(line); };
+
+        if (enableFlatpak() && !QStandardPaths::findExecutable(QStringLiteral("flatpak")).isEmpty()) {
             appendLog(QStringLiteral("[%1] Running Flatpak update (flatpak update -y)...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
-            QProcess proc;
-            proc.setProcessChannelMode(QProcess::MergedChannels);
-            proc.start(QStringLiteral("flatpak"), {QStringLiteral("update"), QStringLiteral("-y")});
-            if (proc.waitForStarted(5000)) {
-                while (proc.state() == QProcess::Running) {
-                    if (proc.waitForReadyRead(200)) {
-                        while (proc.canReadLine()) {
-                            QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                            if (!line.isEmpty()) appendLog(line);
-                        }
-                    }
-                }
-                QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-                if (!rest.isEmpty()) {
-                    for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-                        appendLog(line.trimmed());
-                    }
-                }
-            }
+            astra::runProcessStreaming(QStringLiteral("flatpak"), {QStringLiteral("update"), QStringLiteral("-y")}, logLine);
         }
 
-        // System updates: either via Caelestia CLI or direct Pacman
-        if (useCaelestia && QFile::exists(QStringLiteral("/usr/bin/caelestia"))) {
+        if (useCaelestia && !QStandardPaths::findExecutable(QStringLiteral("caelestia")).isEmpty()) {
             appendLog(QStringLiteral("[%1] Running Caelestia update (caelestia update --noconfirm)...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
-            QProcess cProc;
-            cProc.setProcessChannelMode(QProcess::MergedChannels);
-            cProc.start(QStringLiteral("caelestia"), {QStringLiteral("update"), QStringLiteral("--noconfirm")});
-            if (cProc.waitForStarted(5000)) {
-                while (cProc.state() == QProcess::Running) {
-                    if (cProc.waitForReadyRead(200)) {
-                        while (cProc.canReadLine()) {
-                            QString line = QString::fromUtf8(cProc.readLine()).trimmed();
-                            if (!line.isEmpty()) appendLog(line);
-                        }
-                    }
-                }
-                QString rest = QString::fromUtf8(cProc.readAll()).trimmed();
-                if (!rest.isEmpty()) {
-                    for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-                        appendLog(line.trimmed());
-                    }
-                }
-            }
-        } else if (enablePacman() && QFile::exists(QStringLiteral("/usr/bin/pacman"))) {
+            astra::runProcessStreaming(QStringLiteral("caelestia"), {QStringLiteral("update"), QStringLiteral("--noconfirm")}, logLine);
+        } else if (enablePacman() && !QStandardPaths::findExecutable(QStringLiteral("pacman")).isEmpty()) {
             appendLog(QStringLiteral("[%1] Running Pacman update (pkexec pacman -Syu --noconfirm)...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
-            QProcess pacProc;
-            pacProc.setProcessChannelMode(QProcess::MergedChannels);
-            pacProc.start(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm")});
-            if (pacProc.waitForStarted(5000)) {
-                while (pacProc.state() == QProcess::Running) {
-                    if (pacProc.waitForReadyRead(200)) {
-                        while (pacProc.canReadLine()) {
-                            QString line = QString::fromUtf8(pacProc.readLine()).trimmed();
-                            if (!line.isEmpty()) appendLog(line);
-                        }
-                    }
-                }
-                QString rest = QString::fromUtf8(pacProc.readAll()).trimmed();
-                if (!rest.isEmpty()) {
-                    for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-                        appendLog(line.trimmed());
-                    }
-                }
-            }
+            astra::runProcessStreaming(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm")}, logLine);
         }
 
         return true;

--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -394,7 +394,7 @@ void PackageManager::installPackage(const QString& backend, const QString& packa
     emit currentProgressChanged();
     QString statusText = QStringLiteral("Installing ") + packageId + QStringLiteral(" (") + backend + QStringLiteral(")...");
     setStatusMessage(statusText);
-    appendLog(QStringLiteral("[%1] Starting installation: %2 [%3, scope: %4]").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), packageId, backend, scope));
+    appendLog(QStringLiteral("[%1] Starting installation: %2 [%3, scope: %4]").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), packageId, backend, scope.isEmpty() ? QStringLiteral("default") : scope));
 
     auto* watcher = new QFutureWatcher<bool>(this);
     connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher, packageId, backend] {
@@ -409,12 +409,53 @@ void PackageManager::installPackage(const QString& backend, const QString& packa
     });
 
     QVariantMap opts;
-    opts[QStringLiteral("scope")] = scope;
+    if (!scope.isEmpty()) opts[QStringLiteral("scope")] = scope;
 
     QFuture<bool> future = QtConcurrent::run([this, backend, packageId, opts] {
         IPackagePlugin* plugin = findPlugin(backend);
         if (!plugin) return false;
         return plugin->install(packageId, opts, [this, packageId](int pct, const QString& status) {
+            m_currentProgress = pct;
+            emit currentProgressChanged();
+            if (!status.isEmpty()) {
+                appendLog(QStringLiteral("[%1] [%2%] %3").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), QString::number(pct), status));
+            }
+            emit operationProgress(packageId, pct, status);
+        });
+    });
+    watcher->setFuture(future);
+}
+
+void PackageManager::updatePackage(const QString& backend, const QString& packageId, const QString& scope) {
+    setBusy(true);
+    m_currentProgress = 0;
+    emit currentProgressChanged();
+    setStatusMessage(QStringLiteral("Updating ") + packageId + QStringLiteral(" (") + backend + QStringLiteral(")..."));
+    appendLog(QStringLiteral("[%1] Starting update: %2 [%3]").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), packageId, backend));
+
+    if (backend == QStringLiteral("Pacman") || backend == QStringLiteral("AUR")) {
+        appendLog(QStringLiteral("[%1] %2 is upgraded with a full sync (-Syu) to avoid a partial upgrade").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), packageId));
+    }
+
+    auto* watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher, packageId, backend] {
+        const bool success = watcher->result();
+        watcher->deleteLater();
+        setBusy(false);
+        m_currentProgress = success ? 100 : 0;
+        emit currentProgressChanged();
+        setStatusMessage(QString());
+        appendLog(QStringLiteral("[%1] %2: %3 (%4)").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : QStringLiteral("FAILED"), packageId, backend));
+        emit operationFinished(success, success ? QStringLiteral("Successfully updated ") + packageId : QStringLiteral("Failed to update ") + packageId);
+    });
+
+    QVariantMap opts;
+    if (!scope.isEmpty()) opts[QStringLiteral("scope")] = scope;
+
+    QFuture<bool> future = QtConcurrent::run([this, backend, packageId, opts] {
+        IPackagePlugin* plugin = findPlugin(backend);
+        if (!plugin) return false;
+        return plugin->update(packageId, opts, [this, packageId](int pct, const QString& status) {
             m_currentProgress = pct;
             emit currentProgressChanged();
             if (!status.isEmpty()) {
@@ -447,7 +488,7 @@ void PackageManager::uninstallPackage(const QString& backend, const QString& pac
     });
 
     QVariantMap opts;
-    opts[QStringLiteral("scope")] = scope;
+    if (!scope.isEmpty()) opts[QStringLiteral("scope")] = scope;
 
     QFuture<bool> future = QtConcurrent::run([this, backend, packageId, opts] {
         IPackagePlugin* plugin = findPlugin(backend);

--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -97,7 +97,7 @@ bool PackageManager::isFlatpakAvailable() const { return m_flatpakPlugin ? m_fla
 bool PackageManager::isPacmanAvailable() const { return m_pacmanPlugin ? m_pacmanPlugin->isAvailable() : false; }
 bool PackageManager::isAurAvailable() const { return m_aurPlugin ? m_aurPlugin->isAvailable() : false; }
 bool PackageManager::isAppImageAvailable() const { return m_appimagePlugin ? m_appimagePlugin->isAvailable() : false; }
-bool PackageManager::isCaelestiaAvailable() const { return QFile::exists(QStringLiteral("/usr/bin/caelestia")); }
+bool PackageManager::isCaelestiaAvailable() const { return !QStandardPaths::findExecutable(QStringLiteral("caelestia")).isEmpty(); }
 
 bool PackageManager::useCaelestiaUpdate() const {
     QSettings settings(QStringLiteral("AstraMarket"), QStringLiteral("astra"));
@@ -594,30 +594,36 @@ void PackageManager::updateAllPackages() {
         watcher->deleteLater();
         setBusy(false);
         setStatusMessage(QString());
-        appendLog(QStringLiteral("[%1] %2: System update completed").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : QStringLiteral("COMPLETED")));
-        emit operationFinished(success, success ? QStringLiteral("All packages updated successfully") : QStringLiteral("System updates completed"));
+        appendLog(QStringLiteral("[%1] %2: System update completed").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : QStringLiteral("FAILED")));
+        emit operationFinished(success, success ? QStringLiteral("All packages updated successfully") : QStringLiteral("Some updates could not be applied"));
         checkForUpdatesAsync();
     });
 
-    const bool useCaelestia = useCaelestiaUpdate();
-
-    QFuture<bool> future = QtConcurrent::run([this, useCaelestia] {
-        const auto logLine = [this](const QString& line) { appendLog(line); };
-
-        if (enableFlatpak() && !QStandardPaths::findExecutable(QStringLiteral("flatpak")).isEmpty()) {
-            appendLog(QStringLiteral("[%1] Running Flatpak update (flatpak update -y)...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
-            astra::runProcessStreaming(QStringLiteral("flatpak"), {QStringLiteral("update"), QStringLiteral("-y")}, logLine);
-        }
-
-        if (useCaelestia && !QStandardPaths::findExecutable(QStringLiteral("caelestia")).isEmpty()) {
-            appendLog(QStringLiteral("[%1] Running Caelestia update (caelestia update --noconfirm)...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
-            astra::runProcessStreaming(QStringLiteral("caelestia"), {QStringLiteral("update"), QStringLiteral("--noconfirm")}, logLine);
-        } else if (enablePacman() && !QStandardPaths::findExecutable(QStringLiteral("pacman")).isEmpty()) {
-            appendLog(QStringLiteral("[%1] Running Pacman update (pkexec pacman -Syu --noconfirm)...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
-            astra::runProcessStreaming(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm")}, logLine);
-        }
-
-        return true;
+    QFuture<bool> future = QtConcurrent::run([this] {
+        return runSystemUpdate([this](const QString& line) { appendLog(line); });
     });
     watcher->setFuture(future);
+}
+
+bool PackageManager::runSystemUpdate(const std::function<void(const QString&)>& logCallback) {
+    const auto stamped = [&logCallback](const QString& message) {
+        logCallback(QStringLiteral("[%1] %2").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), message));
+    };
+
+    bool success = true;
+
+    if (enableFlatpak() && !QStandardPaths::findExecutable(QStringLiteral("flatpak")).isEmpty()) {
+        stamped(QStringLiteral("Running Flatpak update (flatpak update -y)..."));
+        success = astra::runProcessStreaming(QStringLiteral("flatpak"), {QStringLiteral("update"), QStringLiteral("-y")}, logCallback).succeeded() && success;
+    }
+
+    if (useCaelestiaUpdate() && !QStandardPaths::findExecutable(QStringLiteral("caelestia")).isEmpty()) {
+        stamped(QStringLiteral("Running Caelestia update (caelestia update --noconfirm)..."));
+        success = astra::runProcessStreaming(QStringLiteral("caelestia"), {QStringLiteral("update"), QStringLiteral("--noconfirm")}, logCallback).succeeded() && success;
+    } else if (enablePacman() && !QStandardPaths::findExecutable(QStringLiteral("pacman")).isEmpty()) {
+        stamped(QStringLiteral("Running Pacman update (pkexec pacman -Syu --noconfirm)..."));
+        success = astra::runProcessStreaming(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm")}, logCallback).succeeded() && success;
+    }
+
+    return success;
 }

--- a/src/marketplace/packagemanager.hpp
+++ b/src/marketplace/packagemanager.hpp
@@ -80,8 +80,9 @@ public:
     Q_INVOKABLE QVariantList searchPackages(const QString& query, const QString& sourceFilter = QString());
     Q_INVOKABLE void searchPackagesAsync(const QString& query, const QString& sourceFilter = QString());
     Q_INVOKABLE void getInstalledPackagesAsync();
-    Q_INVOKABLE void installPackage(const QString& backend, const QString& packageId, const QString& scope = QStringLiteral("user"));
-    Q_INVOKABLE void uninstallPackage(const QString& backend, const QString& packageId, const QString& scope = QStringLiteral("user"));
+    Q_INVOKABLE void installPackage(const QString& backend, const QString& packageId, const QString& scope = QString());
+    Q_INVOKABLE void updatePackage(const QString& backend, const QString& packageId, const QString& scope = QString());
+    Q_INVOKABLE void uninstallPackage(const QString& backend, const QString& packageId, const QString& scope = QString());
     Q_INVOKABLE void launchApp(const QString& backend, const QString& packageId, const QString& execPath = QString());
     Q_INVOKABLE QString getIconPath(const QString& iconName, const QString& backend = QString());
     Q_INVOKABLE QVariantMap getPackageDetails(const QString& packageId, const QString& backend = QString());

--- a/src/marketplace/packagemanager.hpp
+++ b/src/marketplace/packagemanager.hpp
@@ -69,6 +69,8 @@ public:
     void setUseCaelestiaUpdate(bool enable);
     void setAurHelper(const QString& helper);
 
+    bool runSystemUpdate(const std::function<void(const QString&)>& logCallback);
+
     void registerPlugin(IPackagePlugin* plugin);
     QList<IPackagePlugin*> plugins() const { return m_plugins; }
     IPackagePlugin* findPlugin(const QString& backendOrId) const;

--- a/src/marketplace/pluginprocess.cpp
+++ b/src/marketplace/pluginprocess.cpp
@@ -22,11 +22,16 @@ QProcessEnvironment parsableEnvironment() {
     return environment;
 }
 
-ProcessResult run(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs, bool mergeChannels) {
+ProcessResult run(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs, bool mergeChannels, const ProcessEnvironmentOverrides& environmentOverrides) {
     ProcessResult result;
 
+    QProcessEnvironment environment = parsableEnvironment();
+    for (auto it = environmentOverrides.constBegin(); it != environmentOverrides.constEnd(); ++it) {
+        environment.insert(it.key(), it.value());
+    }
+
     QProcess process;
-    process.setProcessEnvironment(parsableEnvironment());
+    process.setProcessEnvironment(environment);
     if (mergeChannels) process.setProcessChannelMode(QProcess::MergedChannels);
     process.start(program, arguments);
 
@@ -94,11 +99,11 @@ ProcessResult run(const QString& program, const QStringList& arguments, const Pr
 }
 
 ProcessResult runProcess(const QString& program, const QStringList& arguments, int timeoutMs) {
-    return run(program, arguments, nullptr, timeoutMs, false);
+    return run(program, arguments, nullptr, timeoutMs, false, {});
 }
 
-ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs) {
-    return run(program, arguments, lineCallback, timeoutMs, true);
+ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs, const ProcessEnvironmentOverrides& environmentOverrides) {
+    return run(program, arguments, lineCallback, timeoutMs, true, environmentOverrides);
 }
 
 }

--- a/src/marketplace/pluginprocess.cpp
+++ b/src/marketplace/pluginprocess.cpp
@@ -1,0 +1,104 @@
+#include "pluginprocess.hpp"
+
+#include <QElapsedTimer>
+#include <QProcess>
+#include <QProcessEnvironment>
+
+namespace astra {
+
+namespace {
+
+constexpr int kStartTimeoutMs = 5000;
+
+QProcessEnvironment parsableEnvironment() {
+    static const QProcessEnvironment environment = [] {
+        QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+        env.insert(QStringLiteral("LC_ALL"), QStringLiteral("C.UTF-8"));
+        env.insert(QStringLiteral("LANG"), QStringLiteral("C.UTF-8"));
+        env.remove(QStringLiteral("LANGUAGE"));
+        env.remove(QStringLiteral("LC_MESSAGES"));
+        return env;
+    }();
+    return environment;
+}
+
+ProcessResult run(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs, bool mergeChannels) {
+    ProcessResult result;
+
+    QProcess process;
+    process.setProcessEnvironment(parsableEnvironment());
+    if (mergeChannels) process.setProcessChannelMode(QProcess::MergedChannels);
+    process.start(program, arguments);
+
+    if (!process.waitForStarted(kStartTimeoutMs)) {
+        result.error = process.errorString();
+        process.kill();
+        process.waitForFinished(1000);
+        return result;
+    }
+    result.started = true;
+
+    QElapsedTimer elapsed;
+    elapsed.start();
+    QString pending;
+
+    const auto drain = [&](bool flush) {
+        const QString chunk = QString::fromUtf8(process.readAllStandardOutput());
+        if (!chunk.isEmpty()) {
+            result.output += chunk;
+            if (lineCallback) pending += chunk;
+        }
+        if (!mergeChannels) result.error += QString::fromUtf8(process.readAllStandardError());
+
+        if (!lineCallback) return;
+        while (true) {
+            qsizetype breakAt = -1;
+            for (qsizetype i = 0; i < pending.size(); ++i) {
+                const QChar character = pending.at(i);
+                if (character == QLatin1Char('\n') || character == QLatin1Char('\r')) {
+                    breakAt = i;
+                    break;
+                }
+            }
+            if (breakAt < 0) break;
+            const QString line = pending.left(breakAt).trimmed();
+            pending.remove(0, breakAt + 1);
+            if (!line.isEmpty()) lineCallback(line);
+        }
+        if (flush && !pending.isEmpty()) {
+            const QString line = pending.trimmed();
+            pending.clear();
+            if (!line.isEmpty()) lineCallback(line);
+        }
+    };
+
+    while (process.state() == QProcess::Running) {
+        process.waitForReadyRead(200);
+        drain(false);
+
+        if (timeoutMs > 0 && elapsed.hasExpired(timeoutMs)) {
+            result.timedOut = true;
+            process.kill();
+            process.waitForFinished(1000);
+            break;
+        }
+    }
+
+    process.waitForFinished(1000);
+    drain(true);
+
+    if (!result.timedOut) result.exitCode = process.exitCode();
+    return result;
+}
+
+}
+
+ProcessResult runProcess(const QString& program, const QStringList& arguments, int timeoutMs) {
+    return run(program, arguments, nullptr, timeoutMs, false);
+}
+
+ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs) {
+    return run(program, arguments, lineCallback, timeoutMs, true);
+}
+
+}

--- a/src/marketplace/pluginprocess.hpp
+++ b/src/marketplace/pluginprocess.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <functional>
+
+namespace astra {
+
+struct ProcessResult {
+    int exitCode{-1};
+    bool timedOut{false};
+    bool started{false};
+    QString output;
+    QString error;
+
+    bool succeeded() const { return started && !timedOut && exitCode == 0; }
+};
+
+using ProcessLineCallback = std::function<void(const QString& line)>;
+
+ProcessResult runProcess(const QString& program, const QStringList& arguments, int timeoutMs = 15000);
+ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs = 0);
+
+}

--- a/src/marketplace/pluginprocess.hpp
+++ b/src/marketplace/pluginprocess.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QMap>
 #include <QString>
 #include <QStringList>
 #include <functional>
@@ -18,7 +19,9 @@ struct ProcessResult {
 
 using ProcessLineCallback = std::function<void(const QString& line)>;
 
+using ProcessEnvironmentOverrides = QMap<QString, QString>;
+
 ProcessResult runProcess(const QString& program, const QStringList& arguments, int timeoutMs = 15000);
-ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs = 0);
+ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs = 0, const ProcessEnvironmentOverrides& environmentOverrides = {});
 
 }

--- a/src/marketplace/plugins/aurplugin.cpp
+++ b/src/marketplace/plugins/aurplugin.cpp
@@ -1,7 +1,9 @@
 #include "aurplugin.hpp"
+#include "pluginprocess.hpp"
 #include <QProcess>
 #include <QFile>
 #include <QSet>
+#include <QStandardPaths>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -10,6 +12,12 @@
 #include <QNetworkReply>
 #include <QEventLoop>
 #include <QUrl>
+
+namespace {
+constexpr int kQueryTimeoutMs = 15000;
+constexpr int kUpdatesTimeoutMs = 30000;
+constexpr int kNetworkTimeoutMs = 10000;
+}
 
 AurPlugin::AurPlugin(QObject* parent) : IPackagePlugin(parent) {
     m_enabled = m_settings.value(QStringLiteral("AUR/enabled"), true).toBool();
@@ -22,10 +30,11 @@ bool AurPlugin::isAvailable() const {
 
 QString AurPlugin::resolveHelper() const {
     if (!m_aurHelper.isEmpty() && m_aurHelper != QStringLiteral("auto")) {
-        if (QFile::exists(QStringLiteral("/usr/bin/") + m_aurHelper)) return m_aurHelper;
+        if (!QStandardPaths::findExecutable(m_aurHelper).isEmpty()) return m_aurHelper;
     }
-    if (QFile::exists(QStringLiteral("/usr/bin/paru"))) return QStringLiteral("paru");
-    if (QFile::exists(QStringLiteral("/usr/bin/yay"))) return QStringLiteral("yay");
+    for (const QString& candidate : {QStringLiteral("paru"), QStringLiteral("yay")}) {
+        if (!QStandardPaths::findExecutable(candidate).isEmpty()) return candidate;
+    }
     return QString();
 }
 
@@ -57,6 +66,7 @@ QVariantList AurPlugin::search(const QString& query, const QVariantMap& options)
     QUrl url(QStringLiteral("https://aur.archlinux.org/rpc/v5/search/") + QUrl::toPercentEncoding(q));
     QNetworkRequest req(url);
     req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
+    req.setTransferTimeout(kNetworkTimeoutMs);
 
     QEventLoop loop;
     QNetworkReply* reply = nam.get(req);
@@ -89,31 +99,54 @@ QVariantList AurPlugin::search(const QString& query, const QVariantMap& options)
     return results;
 }
 
+QVariantList AurPlugin::parseForeignOutput(const QString& output) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 2) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = parts.value(0);
+        item[QStringLiteral("name")] = parts.value(0);
+        item[QStringLiteral("version")] = parts.value(1);
+        item[QStringLiteral("backend")] = QStringLiteral("AUR");
+        item[QStringLiteral("repository")] = QStringLiteral("local");
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = parts.value(0);
+        item[QStringLiteral("isInstalled")] = true;
+        results.append(item);
+    }
+    return results;
+}
+
+QVariantList AurPlugin::parseUpdatesOutput(const QString& output) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 4) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = parts.value(0);
+        item[QStringLiteral("name")] = parts.value(0);
+        item[QStringLiteral("version")] = parts.value(1) + QStringLiteral(" -> ") + parts.value(3);
+        item[QStringLiteral("backend")] = QStringLiteral("AUR");
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = parts.value(0);
+        results.append(item);
+    }
+    return results;
+}
+
 QVariantList AurPlugin::getInstalled() {
     QVariantList results;
     if (!m_enabled) return results;
 
-    QProcess qmProc;
-    qmProc.start(QStringLiteral("pacman"), {QStringLiteral("-Qm")});
-    if (qmProc.waitForFinished(3000)) {
-        QString output = QString::fromUtf8(qmProc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& line : lines) {
-            QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (parts.size() >= 2) {
-                QVariantMap item;
-                item[QStringLiteral("id")] = parts.value(0);
-                item[QStringLiteral("name")] = parts.value(0);
-                item[QStringLiteral("version")] = parts.value(1);
-                item[QStringLiteral("backend")] = QStringLiteral("AUR");
-                item[QStringLiteral("repository")] = QStringLiteral("local");
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = parts.value(0);
-                item[QStringLiteral("isInstalled")] = true;
-                results.append(item);
-            }
-        }
-    }
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qm")}, kQueryTimeoutMs);
+    results.append(parseForeignOutput(result.output));
     return results;
 }
 
@@ -124,25 +157,8 @@ QVariantList AurPlugin::getUpdates() {
     QString helper = resolveHelper();
     if (helper.isEmpty()) return results;
 
-    QProcess proc;
-    proc.start(helper, {QStringLiteral("-Qua")});
-    if (proc.waitForFinished(8000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& line : lines) {
-            QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (parts.size() >= 4) {
-                QVariantMap item;
-                item[QStringLiteral("id")] = parts.value(0);
-                item[QStringLiteral("name")] = parts.value(0);
-                item[QStringLiteral("version")] = parts.value(1) + QStringLiteral(" -> ") + parts.value(3);
-                item[QStringLiteral("backend")] = QStringLiteral("AUR");
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = parts.value(0);
-                results.append(item);
-            }
-        }
-    }
+    const astra::ProcessResult result = astra::runProcess(helper, {QStringLiteral("-Qua")}, kUpdatesTimeoutMs);
+    results.append(parseUpdatesOutput(result.output));
     return results;
 }
 
@@ -156,6 +172,7 @@ QVariantMap AurPlugin::getDetails(const QString& packageId) {
     QUrl url(QStringLiteral("https://aur.archlinux.org/rpc/v5/info/") + QUrl::toPercentEncoding(packageId));
     QNetworkRequest req(url);
     req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
+    req.setTransferTimeout(kNetworkTimeoutMs);
 
     QEventLoop loop;
     QNetworkReply* reply = nam.get(req);
@@ -191,50 +208,18 @@ bool AurPlugin::install(const QString& packageId, const QVariantMap& options, Pr
     QString helper = resolveHelper();
     if (helper.isEmpty()) return false;
 
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(helper, {QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId});
-    if (!proc.waitForStarted(5000)) return false;
-
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            while (proc.canReadLine()) {
-                QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                if (!line.isEmpty() && progressCb) progressCb(50, line);
-            }
-        }
-    }
-    QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-    if (!rest.isEmpty() && progressCb) {
-        for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-            progressCb(100, line.trimmed());
-        }
-    }
-    return proc.exitCode() == 0;
+    const astra::ProcessResult result = astra::runProcessStreaming(helper, {QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId}, [&progressCb](const QString& line) {
+        if (progressCb) progressCb(50, line);
+    });
+    return result.succeeded();
 }
 
 bool AurPlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     Q_UNUSED(options);
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Rns"), QStringLiteral("--noconfirm"), packageId});
-    if (!proc.waitForStarted(5000)) return false;
-
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            while (proc.canReadLine()) {
-                QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                if (!line.isEmpty() && progressCb) progressCb(50, line);
-            }
-        }
-    }
-    QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-    if (!rest.isEmpty() && progressCb) {
-        for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-            progressCb(100, line.trimmed());
-        }
-    }
-    return proc.exitCode() == 0;
+    const astra::ProcessResult result = astra::runProcessStreaming(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Rns"), QStringLiteral("--noconfirm"), packageId}, [&progressCb](const QString& line) {
+        if (progressCb) progressCb(50, line);
+    });
+    return result.succeeded();
 }
 
 bool AurPlugin::launch(const QString& packageId) {

--- a/src/marketplace/plugins/aurplugin.cpp
+++ b/src/marketplace/plugins/aurplugin.cpp
@@ -1,6 +1,7 @@
 #include "aurplugin.hpp"
 #include "pluginprocess.hpp"
 #include <algorithm>
+#include <QDateTime>
 #include <QProcess>
 #include <QFile>
 #include <QSet>
@@ -245,14 +246,32 @@ QVariantMap AurPlugin::getDetails(const QString& packageId) {
 
                 map[QStringLiteral("description")] = obj[QStringLiteral("Description")].toString();
                 map[QStringLiteral("homepage")] = obj[QStringLiteral("URL")].toString();
+                map[QStringLiteral("url")] = obj[QStringLiteral("URL")].toString();
                 map[QStringLiteral("aurPage")] = QStringLiteral("https://aur.archlinux.org/packages/") + packageId;
 
-                if (obj[QStringLiteral("License")].isArray()) {
-                    QStringList licenses;
-                    for (const QJsonValue& license : obj[QStringLiteral("License")].toArray()) {
-                        licenses.append(license.toString());
+                const auto joinArray = [&obj](const QString& field) {
+                    QStringList values;
+                    for (const QJsonValue& value : obj[field].toArray()) {
+                        values.append(value.toString());
                     }
+                    return values;
+                };
+
+                const QStringList licenses = joinArray(QStringLiteral("License"));
+                if (!licenses.isEmpty()) {
                     map[QStringLiteral("license")] = licenses.join(QStringLiteral(", "));
+                    map[QStringLiteral("licenses")] = licenses.join(QStringLiteral(", "));
+                }
+
+                const QStringList provides = joinArray(QStringLiteral("Provides"));
+                if (!provides.isEmpty()) map[QStringLiteral("provides")] = provides.join(QStringLiteral(", "));
+
+                const QStringList depends = joinArray(QStringLiteral("Depends"));
+                if (!depends.isEmpty()) map[QStringLiteral("depends")] = depends;
+
+                const qint64 lastModified = obj[QStringLiteral("LastModified")].toInteger();
+                if (lastModified > 0) {
+                    map[QStringLiteral("buildDate")] = QDateTime::fromSecsSinceEpoch(lastModified).toString(QStringLiteral("yyyy-MM-dd"));
                 }
             }
         }

--- a/src/marketplace/plugins/aurplugin.cpp
+++ b/src/marketplace/plugins/aurplugin.cpp
@@ -222,6 +222,20 @@ bool AurPlugin::uninstall(const QString& packageId, const QVariantMap& options, 
     return result.succeeded();
 }
 
+bool AurPlugin::update(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
+    Q_UNUSED(options);
+    const QString helper = resolveHelper();
+    if (helper.isEmpty()) return false;
+
+    const astra::ProcessResult result = astra::runProcessStreaming(
+        helper,
+        {QStringLiteral("-Syu"), QStringLiteral("--noconfirm"), packageId},
+        [&progressCb](const QString& line) {
+            if (progressCb) progressCb(50, line);
+        });
+    return result.succeeded();
+}
+
 bool AurPlugin::launch(const QString& packageId) {
     return QProcess::startDetached(packageId);
 }

--- a/src/marketplace/plugins/aurplugin.cpp
+++ b/src/marketplace/plugins/aurplugin.cpp
@@ -1,5 +1,6 @@
 #include "aurplugin.hpp"
 #include "pluginprocess.hpp"
+#include <algorithm>
 #include <QProcess>
 #include <QFile>
 #include <QSet>
@@ -15,8 +16,56 @@
 
 namespace {
 constexpr int kQueryTimeoutMs = 15000;
+constexpr int kSudoProbeTimeoutMs = 5000;
+
+bool sudoIsAuthorised() {
+    return astra::runProcess(QStringLiteral("sudo"), {QStringLiteral("-n"), QStringLiteral("true")}, kSudoProbeTimeoutMs).succeeded();
+}
+
+QString findAskpass() {
+    const QString configured = qEnvironmentVariable("SUDO_ASKPASS");
+    if (!configured.isEmpty() && QFile::exists(configured)) return configured;
+
+    const QStringList candidates{
+        QStringLiteral("/usr/bin/ksshaskpass"),
+        QStringLiteral("/usr/bin/lxqt-openssh-askpass"),
+        QStringLiteral("/usr/bin/ssh-askpass"),
+        QStringLiteral("/usr/bin/x11-ssh-askpass"),
+        QStringLiteral("/usr/lib/ssh/ssh-askpass"),
+        QStringLiteral("/usr/lib/ssh/x11-ssh-askpass"),
+        QStringLiteral("/usr/lib/seahorse/ssh-askpass")
+    };
+    for (const QString& candidate : candidates) {
+        if (QFile::exists(candidate)) return candidate;
+    }
+    return QString();
+}
 constexpr int kUpdatesTimeoutMs = 30000;
 constexpr int kNetworkTimeoutMs = 10000;
+constexpr int kMaxSearchResults = 100;
+
+QVariantMap itemFromRpcObject(const QJsonObject& object) {
+    const QString name = object[QStringLiteral("Name")].toString();
+
+    QVariantMap item;
+    item[QStringLiteral("id")] = name;
+    item[QStringLiteral("name")] = name;
+    item[QStringLiteral("version")] = object[QStringLiteral("Version")].toString();
+    item[QStringLiteral("summary")] = object[QStringLiteral("Description")].toString();
+    item[QStringLiteral("backend")] = QStringLiteral("AUR");
+    item[QStringLiteral("repository")] = QStringLiteral("aur");
+    item[QStringLiteral("scope")] = QStringLiteral("system");
+    item[QStringLiteral("icon")] = name;
+    item[QStringLiteral("votes")] = object[QStringLiteral("NumVotes")].toInt();
+    item[QStringLiteral("popularity")] = object[QStringLiteral("Popularity")].toDouble();
+    item[QStringLiteral("outOfDate")] = !object[QStringLiteral("OutOfDate")].isNull();
+    item[QStringLiteral("orphaned")] = object[QStringLiteral("Maintainer")].isNull();
+
+    const QString maintainer = object[QStringLiteral("Maintainer")].toString();
+    if (!maintainer.isEmpty()) item[QStringLiteral("developer")] = maintainer;
+
+    return item;
+}
 }
 
 AurPlugin::AurPlugin(QObject* parent) : IPackagePlugin(parent) {
@@ -77,20 +126,23 @@ QVariantList AurPlugin::search(const QString& query, const QVariantMap& options)
         QByteArray data = reply->readAll();
         QJsonDocument doc = QJsonDocument::fromJson(data);
         if (doc.isObject() && doc.object().contains(QStringLiteral("results"))) {
-            QJsonArray arr = doc.object()[QStringLiteral("results")].toArray();
-            int count = 0;
-            for (const QJsonValue& val : arr) {
-                if (++count > 50) break;
-                QJsonObject obj = val.toObject();
-                QVariantMap item;
-                item[QStringLiteral("id")] = obj[QStringLiteral("Name")].toString();
-                item[QStringLiteral("name")] = obj[QStringLiteral("Name")].toString();
-                item[QStringLiteral("version")] = obj[QStringLiteral("Version")].toString();
-                item[QStringLiteral("summary")] = obj[QStringLiteral("Description")].toString();
-                item[QStringLiteral("backend")] = QStringLiteral("AUR");
-                item[QStringLiteral("repository")] = QStringLiteral("aur");
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = obj[QStringLiteral("Name")].toString();
+            const QJsonArray entries = doc.object()[QStringLiteral("results")].toArray();
+            QList<QVariantMap> items;
+            items.reserve(entries.size());
+            for (const QJsonValue& value : entries) {
+                items.append(itemFromRpcObject(value.toObject()));
+            }
+
+            const QString needle = q.toLower();
+            std::stable_sort(items.begin(), items.end(), [&needle](const QVariantMap& left, const QVariantMap& right) {
+                const bool leftExact = left.value(QStringLiteral("name")).toString().toLower() == needle;
+                const bool rightExact = right.value(QStringLiteral("name")).toString().toLower() == needle;
+                if (leftExact != rightExact) return leftExact;
+                return left.value(QStringLiteral("popularity")).toDouble() > right.value(QStringLiteral("popularity")).toDouble();
+            });
+
+            for (const QVariantMap& item : items) {
+                if (results.size() >= kMaxSearchResults) break;
                 results.append(item);
             }
         }
@@ -185,16 +237,22 @@ QVariantMap AurPlugin::getDetails(const QString& packageId) {
         if (doc.isObject() && doc.object().contains(QStringLiteral("results"))) {
             QJsonArray arr = doc.object()[QStringLiteral("results")].toArray();
             if (!arr.isEmpty()) {
-                QJsonObject obj = arr.first().toObject();
-                map[QStringLiteral("summary")] = obj[QStringLiteral("Description")].toString();
+                const QJsonObject obj = arr.first().toObject();
+                const QVariantMap item = itemFromRpcObject(obj);
+                for (auto it = item.constBegin(); it != item.constEnd(); ++it) {
+                    map[it.key()] = it.value();
+                }
+
                 map[QStringLiteral("description")] = obj[QStringLiteral("Description")].toString();
-                map[QStringLiteral("version")] = obj[QStringLiteral("Version")].toString();
                 map[QStringLiteral("homepage")] = obj[QStringLiteral("URL")].toString();
-                map[QStringLiteral("developer")] = obj[QStringLiteral("Maintainer")].toString();
-                if (obj.contains(QStringLiteral("License")) && obj[QStringLiteral("License")].isArray()) {
-                    QStringList lic;
-                    for (const auto& l : obj[QStringLiteral("License")].toArray()) lic.append(l.toString());
-                    map[QStringLiteral("license")] = lic.join(QStringLiteral(", "));
+                map[QStringLiteral("aurPage")] = QStringLiteral("https://aur.archlinux.org/packages/") + packageId;
+
+                if (obj[QStringLiteral("License")].isArray()) {
+                    QStringList licenses;
+                    for (const QJsonValue& license : obj[QStringLiteral("License")].toArray()) {
+                        licenses.append(license.toString());
+                    }
+                    map[QStringLiteral("license")] = licenses.join(QStringLiteral(", "));
                 }
             }
         }
@@ -203,15 +261,60 @@ QVariantMap AurPlugin::getDetails(const QString& packageId) {
     return map;
 }
 
+AurPlugin::HelperInvocation AurPlugin::buildHelperInvocation(const QStringList& operation) const {
+    HelperInvocation invocation;
+    invocation.arguments = operation;
+
+    const QString helper = resolveHelper();
+    if (helper.isEmpty()) {
+        invocation.reason = QStringLiteral("No AUR helper found, install paru or yay");
+        return invocation;
+    }
+
+    if (sudoIsAuthorised()) {
+        invocation.usable = true;
+        return invocation;
+    }
+
+    const bool supportsSudoFlags = helper == QStringLiteral("paru") || helper == QStringLiteral("yay");
+    if (!supportsSudoFlags) {
+        invocation.reason = QStringLiteral("%1 needs a password and cannot be asked for one here, run `sudo -v` first").arg(helper);
+        return invocation;
+    }
+
+    const QString askpass = findAskpass();
+    if (askpass.isEmpty()) {
+        invocation.reason = QStringLiteral("%1 needs a password: run `sudo -v` in a terminal first, or install an askpass helper such as ksshaskpass").arg(helper);
+        return invocation;
+    }
+
+    invocation.arguments << QStringLiteral("--sudoflags") << QStringLiteral("-A");
+    invocation.environment.insert(QStringLiteral("SUDO_ASKPASS"), askpass);
+    invocation.usable = true;
+    return invocation;
+}
+
+bool AurPlugin::runHelperOperation(const QStringList& operation, ProgressCallback progressCb) {
+    const QString helper = resolveHelper();
+    const HelperInvocation invocation = buildHelperInvocation(operation);
+    if (!invocation.usable) {
+        if (progressCb) progressCb(0, invocation.reason);
+        return false;
+    }
+
+    const astra::ProcessResult result = astra::runProcessStreaming(helper, invocation.arguments, [&progressCb](const QString& line) {
+        if (progressCb) progressCb(50, line);
+    }, 0, invocation.environment);
+
+    if (progressCb && !result.succeeded() && result.started) {
+        progressCb(0, QStringLiteral("%1 exited with status %2").arg(helper, QString::number(result.exitCode)));
+    }
+    return result.succeeded();
+}
+
 bool AurPlugin::install(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     Q_UNUSED(options);
-    QString helper = resolveHelper();
-    if (helper.isEmpty()) return false;
-
-    const astra::ProcessResult result = astra::runProcessStreaming(helper, {QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId}, [&progressCb](const QString& line) {
-        if (progressCb) progressCb(50, line);
-    });
-    return result.succeeded();
+    return runHelperOperation({QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId}, progressCb);
 }
 
 bool AurPlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
@@ -224,16 +327,7 @@ bool AurPlugin::uninstall(const QString& packageId, const QVariantMap& options, 
 
 bool AurPlugin::update(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     Q_UNUSED(options);
-    const QString helper = resolveHelper();
-    if (helper.isEmpty()) return false;
-
-    const astra::ProcessResult result = astra::runProcessStreaming(
-        helper,
-        {QStringLiteral("-Syu"), QStringLiteral("--noconfirm"), packageId},
-        [&progressCb](const QString& line) {
-            if (progressCb) progressCb(50, line);
-        });
-    return result.succeeded();
+    return runHelperOperation({QStringLiteral("-Syu"), QStringLiteral("--noconfirm"), packageId}, progressCb);
 }
 
 bool AurPlugin::launch(const QString& packageId) {

--- a/src/marketplace/plugins/aurplugin.hpp
+++ b/src/marketplace/plugins/aurplugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "packageplugin.hpp"
+#include <QMap>
 #include <QSettings>
 
 class AurPlugin : public IPackagePlugin {
@@ -34,6 +35,16 @@ public:
     static QVariantList parseUpdatesOutput(const QString& output);
 
 private:
+    struct HelperInvocation {
+        bool usable{false};
+        QString reason;
+        QStringList arguments;
+        QMap<QString, QString> environment;
+    };
+
+    HelperInvocation buildHelperInvocation(const QStringList& operation) const;
+    bool runHelperOperation(const QStringList& operation, ProgressCallback progressCb);
+
     bool m_enabled{true};
     QString m_aurHelper{QStringLiteral("auto")};
     QSettings m_settings{QStringLiteral("AstraMarket"), QStringLiteral("Plugins")};

--- a/src/marketplace/plugins/aurplugin.hpp
+++ b/src/marketplace/plugins/aurplugin.hpp
@@ -29,6 +29,9 @@ public:
     bool uninstall(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
 
+    static QVariantList parseForeignOutput(const QString& output);
+    static QVariantList parseUpdatesOutput(const QString& output);
+
 private:
     bool m_enabled{true};
     QString m_aurHelper{QStringLiteral("auto")};

--- a/src/marketplace/plugins/aurplugin.hpp
+++ b/src/marketplace/plugins/aurplugin.hpp
@@ -27,6 +27,7 @@ public:
 
     bool install(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool uninstall(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
+    bool update(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
 
     static QVariantList parseForeignOutput(const QString& output);

--- a/src/marketplace/plugins/flatpakplugin.cpp
+++ b/src/marketplace/plugins/flatpakplugin.cpp
@@ -40,6 +40,29 @@ QString withoutProgressBar(QString line) {
 }
 }
 
+QString FlatpakPlugin::scopeArgument(const QString& scope) {
+    return scope == QStringLiteral("system") ? QStringLiteral("--system") : QStringLiteral("--user");
+}
+
+QString FlatpakPlugin::resolveScope(const QString& packageId, const QVariantMap& options) {
+    const QString requested = options.value(QStringLiteral("scope")).toString();
+    if (requested == QStringLiteral("user") || requested == QStringLiteral("system")) return requested;
+
+    const QStringList scopes{QStringLiteral("user"), QStringLiteral("system")};
+    for (const QString& scope : scopes) {
+        const astra::ProcessResult result = astra::runProcess(
+            QStringLiteral("flatpak"),
+            {QStringLiteral("list"), QStringLiteral("--columns=application"), scopeArgument(scope)},
+            kQueryTimeoutMs);
+
+        const QStringList lines = result.output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+        for (const QString& line : lines) {
+            if (line.trimmed().compare(packageId, Qt::CaseInsensitive) == 0) return scope;
+        }
+    }
+    return QStringLiteral("user");
+}
+
 QVariantList FlatpakPlugin::parseSearchOutput(const QString& output, QSet<QString>& seen) {
     QVariantList results;
     const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
@@ -284,11 +307,20 @@ QVariantList FlatpakPlugin::getUpdates() {
     QVariantList results;
     if (!isAvailable() || !m_enabled) return results;
 
-    const astra::ProcessResult result = astra::runProcess(
-        QStringLiteral("flatpak"),
-        {QStringLiteral("remote-ls"), QStringLiteral("--updates"), QStringLiteral("--columns=app,name,version")},
-        kQueryTimeoutMs);
-    results.append(parseUpdatesOutput(result.output));
+    const QStringList scopes{QStringLiteral("user"), QStringLiteral("system")};
+    for (const QString& scope : scopes) {
+        const astra::ProcessResult result = astra::runProcess(
+            QStringLiteral("flatpak"),
+            {QStringLiteral("remote-ls"), QStringLiteral("--updates"), QStringLiteral("--columns=app,name,version"), scopeArgument(scope)},
+            kQueryTimeoutMs);
+
+        const QVariantList updates = parseUpdatesOutput(result.output);
+        for (const QVariant& value : updates) {
+            QVariantMap item = value.toMap();
+            item[QStringLiteral("scope")] = scope;
+            results.append(item);
+        }
+    }
     return results;
 }
 
@@ -359,10 +391,9 @@ QVariantMap FlatpakPlugin::getDetails(const QString& packageId) {
 
 bool FlatpakPlugin::install(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     if (!isAvailable()) return false;
-    QString scope = options.value(QStringLiteral("scope"), QStringLiteral("user")).toString();
     QStringList args;
     args << QStringLiteral("install")
-         << (scope == QStringLiteral("system") ? QStringLiteral("--system") : QStringLiteral("--user"))
+         << scopeArgument(options.value(QStringLiteral("scope")).toString())
          << QStringLiteral("-y")
          << packageId;
 
@@ -377,10 +408,31 @@ bool FlatpakPlugin::install(const QString& packageId, const QVariantMap& options
 }
 
 bool FlatpakPlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
-    Q_UNUSED(options);
     if (!isAvailable()) return false;
     QStringList args;
-    args << QStringLiteral("uninstall") << QStringLiteral("-y") << packageId;
+    args << QStringLiteral("uninstall")
+         << scopeArgument(resolveScope(packageId, options))
+         << QStringLiteral("-y")
+         << packageId;
+
+    const astra::ProcessResult result = astra::runProcessStreaming(QStringLiteral("flatpak"), args, [&progressCb](const QString& line) {
+        if (!progressCb) return;
+        const QString message = withoutProgressBar(line);
+        if (message.isEmpty()) return;
+        const int percent = percentFromLine(line);
+        progressCb(percent < 0 ? 50 : percent, message);
+    });
+    return result.succeeded();
+}
+
+bool FlatpakPlugin::update(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
+    if (!isAvailable()) return false;
+
+    QStringList args;
+    args << QStringLiteral("update")
+         << scopeArgument(resolveScope(packageId, options))
+         << QStringLiteral("-y")
+         << packageId;
 
     const astra::ProcessResult result = astra::runProcessStreaming(QStringLiteral("flatpak"), args, [&progressCb](const QString& line) {
         if (!progressCb) return;

--- a/src/marketplace/plugins/flatpakplugin.cpp
+++ b/src/marketplace/plugins/flatpakplugin.cpp
@@ -1,7 +1,10 @@
 #include "flatpakplugin.hpp"
+#include "pluginprocess.hpp"
 #include <QProcess>
 #include <QFile>
+#include <QRegularExpression>
 #include <QSet>
+#include <QStandardPaths>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -16,7 +19,99 @@ FlatpakPlugin::FlatpakPlugin(QObject* parent) : IPackagePlugin(parent) {
 }
 
 bool FlatpakPlugin::isAvailable() const {
-    return QFile::exists(QStringLiteral("/usr/bin/flatpak")) || QFile::exists(QStringLiteral("/bin/flatpak"));
+    return !QStandardPaths::findExecutable(QStringLiteral("flatpak")).isEmpty();
+}
+
+namespace {
+constexpr int kQueryTimeoutMs = 15000;
+constexpr int kSearchTimeoutMs = 5000;
+constexpr int kDetailsTimeoutMs = 10000;
+
+int percentFromLine(const QString& line) {
+    static const QRegularExpression percentPattern(QStringLiteral(R"((\d{1,3})%)"));
+    const QRegularExpressionMatch match = percentPattern.match(line);
+    return match.hasMatch() ? qBound(0, match.captured(1).toInt(), 100) : -1;
+}
+
+QString withoutProgressBar(QString line) {
+    static const QRegularExpression barPattern(QStringLiteral(R"([\x{2588}\x{2591}\x{2593}\x{2592}\-=|]{2,})"));
+    line.remove(barPattern);
+    return line.simplified();
+}
+}
+
+QVariantList FlatpakPlugin::parseSearchOutput(const QString& output, QSet<QString>& seen) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
+        if (parts.size() < 2) continue;
+
+        const QString appId = parts.value(0).trimmed();
+        if (appId.isEmpty() || seen.contains(appId)) continue;
+        seen.insert(appId);
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = appId;
+        item[QStringLiteral("name")] = parts.value(1).trimmed();
+        item[QStringLiteral("summary")] = parts.size() > 2 ? parts.value(2).trimmed() : QString();
+        item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
+        item[QStringLiteral("scope")] = QStringLiteral("user");
+        item[QStringLiteral("icon")] = appId;
+        results.append(item);
+    }
+    return results;
+}
+
+QVariantList FlatpakPlugin::parseInstalledOutput(const QString& output, const QString& scope) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
+        if (parts.size() < 2) continue;
+
+        const QString appId = parts.value(0).trimmed();
+        if (appId.isEmpty()) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = appId;
+        item[QStringLiteral("name")] = parts.value(1).trimmed().isEmpty() ? appId : parts.value(1).trimmed();
+        const QString version = parts.value(2).trimmed();
+        item[QStringLiteral("version")] = version.isEmpty() ? QStringLiteral("latest") : version;
+        item[QStringLiteral("size")] = parts.value(3).trimmed();
+        item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
+        item[QStringLiteral("scope")] = scope;
+        item[QStringLiteral("icon")] = appId;
+        item[QStringLiteral("isInstalled")] = true;
+        results.append(item);
+    }
+    return results;
+}
+
+QVariantList FlatpakPlugin::parseUpdatesOutput(const QString& output) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
+        if (parts.size() < 2) continue;
+
+        const QString appId = parts.value(0).trimmed();
+        if (appId.isEmpty()) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = appId;
+        item[QStringLiteral("name")] = parts.value(1).trimmed().isEmpty() ? appId : parts.value(1).trimmed();
+        const QString version = parts.value(2).trimmed();
+        item[QStringLiteral("version")] = version.isEmpty() ? QStringLiteral("update") : version;
+        item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
+        item[QStringLiteral("scope")] = QStringLiteral("user");
+        item[QStringLiteral("icon")] = appId;
+        results.append(item);
+    }
+    return results;
 }
 
 void FlatpakPlugin::setEnabled(bool enabled) {
@@ -83,7 +178,7 @@ QVariantList FlatpakPlugin::search(const QString& query, const QVariantMap& opti
             QUrl url(QStringLiteral("https://flathub.org/api/v2/collection/category/") + cat);
             QNetworkRequest req(url);
             req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
-            req.setTransferTimeout(2500);
+            req.setTransferTimeout(kSearchTimeoutMs);
 
             QEventLoop loop;
             QNetworkReply* reply = nam.get(req);
@@ -121,7 +216,7 @@ QVariantList FlatpakPlugin::search(const QString& query, const QVariantMap& opti
         QNetworkRequest req(url);
         req.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
         req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
-        req.setTransferTimeout(2500);
+        req.setTransferTimeout(kSearchTimeoutMs);
 
         QJsonObject jsonBody;
         jsonBody[QStringLiteral("query")] = q;
@@ -157,35 +252,12 @@ QVariantList FlatpakPlugin::search(const QString& query, const QVariantMap& opti
         reply->deleteLater();
     }
 
-    // Local CLI flatpak search as fallback / supplemental
     if (results.size() < 10) {
-        QProcess proc;
-        proc.start(QStringLiteral("flatpak"), {QStringLiteral("search"), q.toLower(), QStringLiteral("--columns=app,name,description")});
-        if (proc.waitForFinished(3000)) {
-            QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-            QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-            for (const QString& line : lines) {
-                QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
-                if (parts.size() >= 2) {
-                    QString appId = parts.value(0).trimmed();
-                    QString appName = parts.value(1).trimmed();
-                    if (appId.isEmpty() || seen.contains(appId)) continue;
-                    seen.insert(appId);
-
-                    QVariantMap item;
-                    item[QStringLiteral("id")] = appId;
-                    item[QStringLiteral("name")] = appName;
-                    item[QStringLiteral("summary")] = parts.size() > 2 ? parts.value(2).trimmed() : QStringLiteral("");
-                    item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
-                    item[QStringLiteral("scope")] = QStringLiteral("user");
-                    item[QStringLiteral("icon")] = appId;
-                    results.append(item);
-                }
-            }
-        } else {
-            proc.kill();
-            proc.waitForFinished(300);
-        }
+        const astra::ProcessResult local = astra::runProcess(
+            QStringLiteral("flatpak"),
+            {QStringLiteral("search"), q.toLower(), QStringLiteral("--columns=app,name,description")},
+            kQueryTimeoutMs);
+        results.append(parseSearchOutput(local.output, seen));
     }
     return results;
 }
@@ -194,33 +266,13 @@ QVariantList FlatpakPlugin::getInstalled() {
     QVariantList results;
     if (!isAvailable() || !m_enabled) return results;
 
-    auto fetchScope = [](const QString& scope) -> QVariantList {
-        QVariantList list;
-        QProcess proc;
-        proc.start(QStringLiteral("flatpak"), {QStringLiteral("list"), QStringLiteral("--app"), QStringLiteral("--columns=app,name,version,size"), scope == QStringLiteral("user") ? QStringLiteral("--user") : QStringLiteral("--system")});
-        if (proc.waitForFinished(5000)) {
-            QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-            QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-            for (const QString& line : lines) {
-                QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
-                if (parts.size() >= 2) {
-                    QVariantMap item;
-                    item[QStringLiteral("id")] = parts.value(0).trimmed();
-                    item[QStringLiteral("name")] = parts.value(1).trimmed().isEmpty() ? parts.value(0).trimmed() : parts.value(1).trimmed();
-                    item[QStringLiteral("version")] = parts.size() > 2 ? parts.value(2).trimmed() : QStringLiteral("latest");
-                    item[QStringLiteral("size")] = parts.size() > 3 ? parts.value(3).trimmed() : QStringLiteral("");
-                    item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
-                    item[QStringLiteral("scope")] = scope;
-                    item[QStringLiteral("icon")] = parts.value(0).trimmed();
-                    item[QStringLiteral("isInstalled")] = true;
-                    list.append(item);
-                }
-            }
-        } else {
-            proc.kill();
-            proc.waitForFinished(500);
-        }
-        return list;
+    const auto fetchScope = [](const QString& scope) -> QVariantList {
+        const astra::ProcessResult result = astra::runProcess(
+            QStringLiteral("flatpak"),
+            {QStringLiteral("list"), QStringLiteral("--app"), QStringLiteral("--columns=app,name,version,size"),
+             scope == QStringLiteral("user") ? QStringLiteral("--user") : QStringLiteral("--system")},
+            kQueryTimeoutMs);
+        return parseInstalledOutput(result.output, scope);
     };
 
     results.append(fetchScope(QStringLiteral("user")));
@@ -232,28 +284,11 @@ QVariantList FlatpakPlugin::getUpdates() {
     QVariantList results;
     if (!isAvailable() || !m_enabled) return results;
 
-    QProcess proc;
-    proc.start(QStringLiteral("flatpak"), {QStringLiteral("remote-ls"), QStringLiteral("--updates"), QStringLiteral("--columns=app,name,version")});
-    if (proc.waitForFinished(8000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& line : lines) {
-            QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
-            if (parts.size() >= 2) {
-                QVariantMap item;
-                item[QStringLiteral("id")] = parts.value(0).trimmed();
-                item[QStringLiteral("name")] = parts.value(1).trimmed();
-                item[QStringLiteral("version")] = parts.size() > 2 ? parts.value(2).trimmed() : QStringLiteral("update");
-                item[QStringLiteral("backend")] = QStringLiteral("Flatpak");
-                item[QStringLiteral("scope")] = QStringLiteral("user");
-                item[QStringLiteral("icon")] = parts.value(0).trimmed();
-                results.append(item);
-            }
-        }
-    } else {
-        proc.kill();
-        proc.waitForFinished(500);
-    }
+    const astra::ProcessResult result = astra::runProcess(
+        QStringLiteral("flatpak"),
+        {QStringLiteral("remote-ls"), QStringLiteral("--updates"), QStringLiteral("--columns=app,name,version")},
+        kQueryTimeoutMs);
+    results.append(parseUpdatesOutput(result.output));
     return results;
 }
 
@@ -276,6 +311,7 @@ QVariantMap FlatpakPlugin::getDetails(const QString& packageId) {
     QNetworkRequest req(url);
     req.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
     req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    req.setTransferTimeout(kDetailsTimeoutMs);
 
     QEventLoop loop;
     QNetworkReply* reply = nam.get(req);
@@ -330,37 +366,14 @@ bool FlatpakPlugin::install(const QString& packageId, const QVariantMap& options
          << QStringLiteral("-y")
          << packageId;
 
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("flatpak"), args);
-    if (!proc.waitForStarted(5000)) return false;
-
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            QByteArray data = proc.readAll();
-            QString output = QString::fromUtf8(data);
-            QStringList chunks = output.split(QRegularExpression(QStringLiteral("[\r\n]+")), Qt::SkipEmptyParts);
-            for (QString chunk : chunks) {
-                chunk = chunk.trimmed();
-                if (chunk.isEmpty()) continue;
-
-                int pct = 50;
-                QRegularExpression pctRe(QStringLiteral(R"((\d{1,3})%)"));
-                auto match = pctRe.match(chunk);
-                if (match.hasMatch()) {
-                    pct = match.captured(1).toInt();
-                }
-
-                chunk.remove(QRegularExpression(QStringLiteral(R"([█░▓▒\-=|]{2,})")));
-                chunk = chunk.simplified();
-
-                if (progressCb && !chunk.isEmpty()) {
-                    progressCb(pct, chunk);
-                }
-            }
-        }
-    }
-    return proc.exitCode() == 0;
+    const astra::ProcessResult result = astra::runProcessStreaming(QStringLiteral("flatpak"), args, [&progressCb](const QString& line) {
+        if (!progressCb) return;
+        const QString message = withoutProgressBar(line);
+        if (message.isEmpty()) return;
+        const int percent = percentFromLine(line);
+        progressCb(percent < 0 ? 50 : percent, message);
+    });
+    return result.succeeded();
 }
 
 bool FlatpakPlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
@@ -369,37 +382,14 @@ bool FlatpakPlugin::uninstall(const QString& packageId, const QVariantMap& optio
     QStringList args;
     args << QStringLiteral("uninstall") << QStringLiteral("-y") << packageId;
 
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("flatpak"), args);
-    if (!proc.waitForStarted(5000)) return false;
-
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            QByteArray data = proc.readAll();
-            QString output = QString::fromUtf8(data);
-            QStringList chunks = output.split(QRegularExpression(QStringLiteral("[\r\n]+")), Qt::SkipEmptyParts);
-            for (QString chunk : chunks) {
-                chunk = chunk.trimmed();
-                if (chunk.isEmpty()) continue;
-
-                int pct = 50;
-                QRegularExpression pctRe(QStringLiteral(R"((\d{1,3})%)"));
-                auto match = pctRe.match(chunk);
-                if (match.hasMatch()) {
-                    pct = match.captured(1).toInt();
-                }
-
-                chunk.remove(QRegularExpression(QStringLiteral(R"([█░▓▒\-=|]{2,})")));
-                chunk = chunk.simplified();
-
-                if (progressCb && !chunk.isEmpty()) {
-                    progressCb(pct, chunk);
-                }
-            }
-        }
-    }
-    return proc.exitCode() == 0;
+    const astra::ProcessResult result = astra::runProcessStreaming(QStringLiteral("flatpak"), args, [&progressCb](const QString& line) {
+        if (!progressCb) return;
+        const QString message = withoutProgressBar(line);
+        if (message.isEmpty()) return;
+        const int percent = percentFromLine(line);
+        progressCb(percent < 0 ? 50 : percent, message);
+    });
+    return result.succeeded();
 }
 
 bool FlatpakPlugin::launch(const QString& packageId) {

--- a/src/marketplace/plugins/flatpakplugin.hpp
+++ b/src/marketplace/plugins/flatpakplugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "packageplugin.hpp"
+#include <QSet>
 #include <QSettings>
 
 class FlatpakPlugin : public IPackagePlugin {
@@ -27,6 +28,10 @@ public:
     bool launch(const QString& packageId) override;
 
     QList<QVariantMap> getInstallSources(const QString& packageId) override;
+
+    static QVariantList parseSearchOutput(const QString& output, QSet<QString>& seen);
+    static QVariantList parseInstalledOutput(const QString& output, const QString& scope);
+    static QVariantList parseUpdatesOutput(const QString& output);
 
 private:
     bool m_enabled{true};

--- a/src/marketplace/plugins/flatpakplugin.hpp
+++ b/src/marketplace/plugins/flatpakplugin.hpp
@@ -25,15 +25,19 @@ public:
 
     bool install(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool uninstall(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
+    bool update(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
 
     QList<QVariantMap> getInstallSources(const QString& packageId) override;
 
+    static QString scopeArgument(const QString& scope);
     static QVariantList parseSearchOutput(const QString& output, QSet<QString>& seen);
     static QVariantList parseInstalledOutput(const QString& output, const QString& scope);
     static QVariantList parseUpdatesOutput(const QString& output);
 
 private:
+    QString resolveScope(const QString& packageId, const QVariantMap& options);
+
     bool m_enabled{true};
     QSettings m_settings{QStringLiteral("AstraMarket"), QStringLiteral("Plugins")};
 };

--- a/src/marketplace/plugins/packageplugin.hpp
+++ b/src/marketplace/plugins/packageplugin.hpp
@@ -30,6 +30,11 @@ public:
 
     virtual bool install(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) = 0;
     virtual bool uninstall(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) = 0;
+
+    virtual bool update(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) {
+        return install(packageId, options, progressCb);
+    }
+
     virtual bool launch(const QString& packageId) = 0;
 
     virtual QList<QVariantMap> getInstallSources(const QString& packageId) {

--- a/src/marketplace/plugins/pacmanplugin.cpp
+++ b/src/marketplace/plugins/pacmanplugin.cpp
@@ -157,11 +157,30 @@ QVariantMap PacmanPlugin::parseInfoOutput(const QString& output, const QString& 
     assign(QStringLiteral("Description"), QStringLiteral("description"));
     assign(QStringLiteral("Version"), QStringLiteral("version"));
     assign(QStringLiteral("URL"), QStringLiteral("homepage"));
+    assign(QStringLiteral("URL"), QStringLiteral("url"));
     assign(QStringLiteral("Licenses"), QStringLiteral("license"));
+    assign(QStringLiteral("Licenses"), QStringLiteral("licenses"));
     assign(QStringLiteral("Packager"), QStringLiteral("developer"));
     assign(QStringLiteral("Repository"), QStringLiteral("repository"));
+    assign(QStringLiteral("Architecture"), QStringLiteral("architecture"));
     assign(QStringLiteral("Installed Size"), QStringLiteral("size"));
+    assign(QStringLiteral("Installed Size"), QStringLiteral("installedSize"));
     assign(QStringLiteral("Download Size"), QStringLiteral("downloadSize"));
+    assign(QStringLiteral("Build Date"), QStringLiteral("buildDate"));
+    assign(QStringLiteral("Install Date"), QStringLiteral("installDate"));
+    assign(QStringLiteral("Install Reason"), QStringLiteral("installReason"));
+    assign(QStringLiteral("Provides"), QStringLiteral("provides"));
+
+    const auto assignList = [&](const QString& field, const QString& key) {
+        const QString value = fields.value(field);
+        if (value.isEmpty() || value == QLatin1String("None")) return;
+
+        const QStringList entries = value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (!entries.isEmpty()) map[key] = entries;
+    };
+
+    assignList(QStringLiteral("Depends On"), QStringLiteral("depends"));
+    assignList(QStringLiteral("Required By"), QStringLiteral("requiredBy"));
 
     return map;
 }
@@ -194,11 +213,26 @@ QVariantList PacmanPlugin::getUpdates() {
 }
 
 QVariantMap PacmanPlugin::getDetails(const QString& packageId) {
-    astra::ProcessResult result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Si"), packageId}, kQueryTimeoutMs);
-    if (!result.succeeded() || result.output.trimmed().isEmpty()) {
-        result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qi"), packageId}, kQueryTimeoutMs);
+    const astra::ProcessResult remote = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Si"), packageId}, kQueryTimeoutMs);
+    const astra::ProcessResult local = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qi"), packageId}, kQueryTimeoutMs);
+
+    QVariantMap map = parseInfoOutput(remote.output, packageId);
+    const QVariantMap installed = parseInfoOutput(local.output, packageId);
+
+    for (auto it = installed.constBegin(); it != installed.constEnd(); ++it) {
+        if (!map.contains(it.key()) || map.value(it.key()).toString().isEmpty()) {
+            map.insert(it.key(), it.value());
+        }
     }
-    return parseInfoOutput(result.output, packageId);
+
+    if (local.succeeded() && !local.output.trimmed().isEmpty()) {
+        map[QStringLiteral("isInstalled")] = true;
+        for (const QString& key : {QStringLiteral("installReason"), QStringLiteral("installDate"), QStringLiteral("requiredBy")}) {
+            if (installed.contains(key)) map.insert(key, installed.value(key));
+        }
+    }
+
+    return map;
 }
 
 bool PacmanPlugin::install(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {

--- a/src/marketplace/plugins/pacmanplugin.cpp
+++ b/src/marketplace/plugins/pacmanplugin.cpp
@@ -1,15 +1,21 @@
 #include "pacmanplugin.hpp"
-#include <QProcess>
+#include "pluginprocess.hpp"
+
 #include <QFile>
-#include <QSet>
-#include <QDir>
+#include <QProcess>
+#include <QStandardPaths>
+
+namespace {
+constexpr int kQueryTimeoutMs = 15000;
+constexpr int kUpdatesTimeoutMs = 30000;
+}
 
 PacmanPlugin::PacmanPlugin(QObject* parent) : IPackagePlugin(parent) {
     m_enabled = m_settings.value(QStringLiteral("Pacman/enabled"), true).toBool();
 }
 
 bool PacmanPlugin::isAvailable() const {
-    return QFile::exists(QStringLiteral("/usr/bin/pacman"));
+    return !QStandardPaths::findExecutable(QStringLiteral("pacman")).isEmpty();
 }
 
 void PacmanPlugin::setEnabled(bool enabled) {
@@ -20,213 +26,232 @@ void PacmanPlugin::setEnabled(bool enabled) {
     }
 }
 
-QVariantList PacmanPlugin::search(const QString& query, const QVariantMap& options) {
-    Q_UNUSED(options);
+QVariantList PacmanPlugin::parseSearchOutput(const QString& output) {
     QVariantList results;
-    if (!isAvailable() || !m_enabled) return results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    QSet<QString> seen;
 
-    QString q = query.trimmed().toLower();
-    if (q.isEmpty()) return results;
+    for (qsizetype i = 0; i < lines.size(); ++i) {
+        const QString& header = lines.at(i);
+        if (header.startsWith(QLatin1Char(' ')) || header.startsWith(QLatin1Char('\t'))) continue;
 
-    QProcess proc;
-    proc.start(QStringLiteral("pacman"), {QStringLiteral("-Ss"), q});
-    if (proc.waitForFinished(5000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        QSet<QString> seen;
-        for (int i = 0; i < lines.size(); i += 2) {
-            QString header = lines[i];
-            QString desc = (i + 1 < lines.size()) ? lines[i + 1].trimmed() : QStringLiteral("");
-            QStringList parts = header.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (!parts.isEmpty()) {
-                QString fullName = parts.first();
-                QString repo = fullName.contains(QLatin1Char('/')) ? fullName.section(QLatin1Char('/'), 0, 0) : QStringLiteral("extra");
-                QString pkgName = fullName.contains(QLatin1Char('/')) ? fullName.section(QLatin1Char('/'), 1) : fullName;
-
-                if (seen.contains(pkgName)) continue;
-                seen.insert(pkgName);
-
-                QVariantMap item;
-                item[QStringLiteral("id")] = pkgName;
-                item[QStringLiteral("name")] = pkgName;
-                item[QStringLiteral("summary")] = desc;
-                item[QStringLiteral("backend")] = QStringLiteral("Pacman");
-                item[QStringLiteral("repository")] = repo;
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = pkgName;
-                results.append(item);
+        QString description;
+        if (i + 1 < lines.size()) {
+            const QString& next = lines.at(i + 1);
+            if (next.startsWith(QLatin1Char(' ')) || next.startsWith(QLatin1Char('\t'))) {
+                description = next.trimmed();
+                ++i;
             }
         }
-    } else {
-        proc.kill();
-        proc.waitForFinished(500);
+
+        const QString fullName = header.split(QLatin1Char(' '), Qt::SkipEmptyParts).value(0);
+        if (fullName.isEmpty()) continue;
+
+        const QString repository = fullName.contains(QLatin1Char('/')) ? fullName.section(QLatin1Char('/'), 0, 0) : QStringLiteral("extra");
+        const QString packageName = fullName.contains(QLatin1Char('/')) ? fullName.section(QLatin1Char('/'), 1) : fullName;
+        if (packageName.isEmpty() || seen.contains(packageName)) continue;
+        seen.insert(packageName);
+
+        const QStringList headerParts = header.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = packageName;
+        item[QStringLiteral("name")] = packageName;
+        item[QStringLiteral("version")] = headerParts.value(1);
+        item[QStringLiteral("summary")] = description;
+        item[QStringLiteral("backend")] = QStringLiteral("Pacman");
+        item[QStringLiteral("repository")] = repository;
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = packageName;
+        item[QStringLiteral("isInstalled")] = header.contains(QStringLiteral("[installed"));
+        results.append(item);
     }
     return results;
 }
 
-QVariantList PacmanPlugin::getInstalled() {
-    QVariantList results;
-    if (!isAvailable() || !m_enabled) return results;
-
-    QSet<QString> localPkgs;
-    QProcess qmProc;
-    qmProc.start(QStringLiteral("pacman"), {QStringLiteral("-Qm")});
-    if (qmProc.waitForFinished(2000)) {
-        QString qmOut = QString::fromUtf8(qmProc.readAllStandardOutput()).trimmed();
-        QStringList qmLines = qmOut.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& l : qmLines) {
-            QString name = l.split(QLatin1Char(' ')).value(0);
-            if (!name.isEmpty()) localPkgs.insert(name);
-        }
-    } else {
-        qmProc.kill();
-        qmProc.waitForFinished(500);
+QSet<QString> PacmanPlugin::parseForeignOutput(const QString& output) {
+    QSet<QString> packages;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    for (const QString& line : lines) {
+        const QString name = line.split(QLatin1Char(' '), Qt::SkipEmptyParts).value(0);
+        if (!name.isEmpty()) packages.insert(name);
     }
+    return packages;
+}
 
-    QProcess proc;
-    proc.start(QStringLiteral("pacman"), {QStringLiteral("-Qe")});
-    if (proc.waitForFinished(5000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        int count = 0;
-        for (const QString& line : lines) {
-            if (++count > 200) break;
-            QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (parts.size() >= 2) {
-                QString pkgId = parts.value(0);
-                if (localPkgs.contains(pkgId)) continue;
+QVariantList PacmanPlugin::parseInstalledOutput(const QString& output, const QSet<QString>& foreign) {
+    QVariantList results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
 
-                QVariantMap item;
-                item[QStringLiteral("id")] = pkgId;
-                item[QStringLiteral("name")] = pkgId;
-                item[QStringLiteral("version")] = parts.value(1);
-                item[QStringLiteral("backend")] = QStringLiteral("Pacman");
-                item[QStringLiteral("repository")] = QStringLiteral("extra");
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = pkgId;
-                item[QStringLiteral("isInstalled")] = true;
-                results.append(item);
-            }
-        }
-    } else {
-        proc.kill();
-        proc.waitForFinished(500);
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 2) continue;
+
+        const QString packageId = parts.value(0);
+        if (foreign.contains(packageId)) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = packageId;
+        item[QStringLiteral("name")] = packageId;
+        item[QStringLiteral("version")] = parts.value(1);
+        item[QStringLiteral("backend")] = QStringLiteral("Pacman");
+        item[QStringLiteral("repository")] = QStringLiteral("extra");
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = packageId;
+        item[QStringLiteral("isInstalled")] = true;
+        results.append(item);
     }
     return results;
 }
 
-QVariantList PacmanPlugin::getUpdates() {
+QVariantList PacmanPlugin::parseUpdatesOutput(const QString& output) {
     QVariantList results;
-    if (!isAvailable() || !m_enabled) return results;
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
 
-    QProcess proc;
-    proc.start(QStringLiteral("checkupdates"));
-    if (proc.waitForFinished(8000)) {
-        QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-        QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-        for (const QString& line : lines) {
-            QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (parts.size() >= 4) {
-                QVariantMap item;
-                item[QStringLiteral("id")] = parts.value(0);
-                item[QStringLiteral("name")] = parts.value(0);
-                item[QStringLiteral("version")] = parts.value(1) + QStringLiteral(" -> ") + parts.value(3);
-                item[QStringLiteral("backend")] = QStringLiteral("Pacman");
-                item[QStringLiteral("scope")] = QStringLiteral("system");
-                item[QStringLiteral("icon")] = parts.value(0);
-                results.append(item);
-            }
-        }
-    } else {
-        proc.kill();
-        proc.waitForFinished(500);
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 4) continue;
+
+        QVariantMap item;
+        item[QStringLiteral("id")] = parts.value(0);
+        item[QStringLiteral("name")] = parts.value(0);
+        item[QStringLiteral("version")] = parts.value(1) + QStringLiteral(" -> ") + parts.value(3);
+        item[QStringLiteral("backend")] = QStringLiteral("Pacman");
+        item[QStringLiteral("scope")] = QStringLiteral("system");
+        item[QStringLiteral("icon")] = parts.value(0);
+        results.append(item);
     }
     return results;
 }
 
-QVariantMap PacmanPlugin::getDetails(const QString& packageId) {
+QVariantMap PacmanPlugin::parseInfoOutput(const QString& output, const QString& packageId) {
     QVariantMap map;
     map[QStringLiteral("id")] = packageId;
     map[QStringLiteral("name")] = packageId;
     map[QStringLiteral("backend")] = QStringLiteral("Pacman");
 
-    QProcess proc;
-    proc.start(QStringLiteral("pacman"), {QStringLiteral("-Si"), packageId});
-    if (!proc.waitForFinished(3000) || proc.exitCode() != 0) {
-        proc.start(QStringLiteral("pacman"), {QStringLiteral("-Qi"), packageId});
-        proc.waitForFinished(3000);
-    }
+    QMap<QString, QString> fields;
+    QString currentField;
 
-    QString output = QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
-    QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    const QStringList lines = output.split(QLatin1Char('\n'));
     for (const QString& line : lines) {
-        if (line.startsWith(QLatin1String("Description"))) {
-            map[QStringLiteral("summary")] = line.section(QLatin1Char(':'), 1).trimmed();
-            map[QStringLiteral("description")] = line.section(QLatin1Char(':'), 1).trimmed();
-        } else if (line.startsWith(QLatin1String("Version"))) {
-            map[QStringLiteral("version")] = line.section(QLatin1Char(':'), 1).trimmed();
-        } else if (line.startsWith(QLatin1String("URL"))) {
-            map[QStringLiteral("homepage")] = line.section(QLatin1Char(':'), 1).trimmed();
-        } else if (line.startsWith(QLatin1String("Licenses"))) {
-            map[QStringLiteral("license")] = line.section(QLatin1Char(':'), 1).trimmed();
-        } else if (line.startsWith(QLatin1String("Packager"))) {
-            map[QStringLiteral("developer")] = line.section(QLatin1Char(':'), 1).trimmed();
+        if (line.trimmed().isEmpty()) continue;
+
+        const qsizetype separator = line.indexOf(QLatin1String(" : "));
+        const bool continuation = line.startsWith(QLatin1Char(' ')) || line.startsWith(QLatin1Char('\t'));
+
+        if (!continuation && separator > 0) {
+            currentField = line.left(separator).trimmed();
+            fields.insert(currentField, line.mid(separator + 3).trimmed());
+        } else if (!currentField.isEmpty()) {
+            fields[currentField] += QLatin1Char(' ') + line.trimmed();
         }
     }
+
+    const auto assign = [&](const QString& field, const QString& key) {
+        const QString value = fields.value(field);
+        if (!value.isEmpty() && value != QLatin1String("None")) map[key] = value;
+    };
+
+    assign(QStringLiteral("Description"), QStringLiteral("summary"));
+    assign(QStringLiteral("Description"), QStringLiteral("description"));
+    assign(QStringLiteral("Version"), QStringLiteral("version"));
+    assign(QStringLiteral("URL"), QStringLiteral("homepage"));
+    assign(QStringLiteral("Licenses"), QStringLiteral("license"));
+    assign(QStringLiteral("Packager"), QStringLiteral("developer"));
+    assign(QStringLiteral("Repository"), QStringLiteral("repository"));
+    assign(QStringLiteral("Installed Size"), QStringLiteral("size"));
+    assign(QStringLiteral("Download Size"), QStringLiteral("downloadSize"));
+
     return map;
+}
+
+QVariantList PacmanPlugin::search(const QString& query, const QVariantMap& options) {
+    Q_UNUSED(options);
+    if (!isAvailable() || !m_enabled) return {};
+
+    const QString trimmed = query.trimmed();
+    if (trimmed.isEmpty()) return {};
+
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Ss"), trimmed.toLower()}, kQueryTimeoutMs);
+    return parseSearchOutput(result.output);
+}
+
+QVariantList PacmanPlugin::getInstalled() {
+    if (!isAvailable() || !m_enabled) return {};
+
+    const astra::ProcessResult foreign = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qm")}, kQueryTimeoutMs);
+    const astra::ProcessResult explicitly = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qe")}, kQueryTimeoutMs);
+    return parseInstalledOutput(explicitly.output, parseForeignOutput(foreign.output));
+}
+
+QVariantList PacmanPlugin::getUpdates() {
+    if (!isAvailable() || !m_enabled) return {};
+    if (QStandardPaths::findExecutable(QStringLiteral("checkupdates")).isEmpty()) return {};
+
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("checkupdates"), {}, kUpdatesTimeoutMs);
+    return parseUpdatesOutput(result.output);
+}
+
+QVariantMap PacmanPlugin::getDetails(const QString& packageId) {
+    astra::ProcessResult result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Si"), packageId}, kQueryTimeoutMs);
+    if (!result.succeeded() || result.output.trimmed().isEmpty()) {
+        result = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qi"), packageId}, kQueryTimeoutMs);
+    }
+    return parseInfoOutput(result.output, packageId);
 }
 
 bool PacmanPlugin::install(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     Q_UNUSED(options);
     if (!isAvailable()) return false;
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId});
-    if (!proc.waitForStarted(5000)) return false;
 
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            while (proc.canReadLine()) {
-                QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                if (!line.isEmpty() && progressCb) progressCb(50, line);
-            }
-        }
+    const astra::ProcessResult result = astra::runProcessStreaming(
+        QStringLiteral("pkexec"),
+        {QStringLiteral("pacman"), QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId},
+        [&progressCb](const QString& line) {
+            if (progressCb) progressCb(50, line);
+        });
+
+    if (progressCb && !result.succeeded() && !result.started) {
+        progressCb(0, QStringLiteral("Could not start pkexec"));
     }
-    QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-    if (!rest.isEmpty() && progressCb) {
-        for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-            progressCb(100, line.trimmed());
-        }
-    }
-    return proc.exitCode() == 0;
+    return result.succeeded();
 }
 
 bool PacmanPlugin::uninstall(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
     Q_UNUSED(options);
     if (!isAvailable()) return false;
-    QProcess proc;
-    proc.setProcessChannelMode(QProcess::MergedChannels);
-    proc.start(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Rns"), QStringLiteral("--noconfirm"), packageId});
-    if (!proc.waitForStarted(5000)) return false;
 
-    while (proc.state() == QProcess::Running) {
-        if (proc.waitForReadyRead(200)) {
-            while (proc.canReadLine()) {
-                QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                if (!line.isEmpty() && progressCb) progressCb(50, line);
-            }
-        }
+    const astra::ProcessResult result = astra::runProcessStreaming(
+        QStringLiteral("pkexec"),
+        {QStringLiteral("pacman"), QStringLiteral("-Rns"), QStringLiteral("--noconfirm"), packageId},
+        [&progressCb](const QString& line) {
+            if (progressCb) progressCb(50, line);
+        });
+
+    if (progressCb && !result.succeeded() && !result.started) {
+        progressCb(0, QStringLiteral("Could not start pkexec"));
     }
-    QString rest = QString::fromUtf8(proc.readAll()).trimmed();
-    if (!rest.isEmpty() && progressCb) {
-        for (const QString& line : rest.split(QLatin1Char('\n'), Qt::SkipEmptyParts)) {
-            progressCb(100, line.trimmed());
-        }
-    }
-    return proc.exitCode() == 0;
+    return result.succeeded();
 }
 
 bool PacmanPlugin::launch(const QString& packageId) {
     if (!isAvailable()) return false;
+
+    const astra::ProcessResult files = astra::runProcess(QStringLiteral("pacman"), {QStringLiteral("-Qlq"), packageId}, kQueryTimeoutMs);
+    const QStringList lines = files.output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+
+    QString fallback;
+    for (const QString& line : lines) {
+        const QString path = line.trimmed();
+        if (!path.startsWith(QLatin1String("/usr/bin/")) || path.endsWith(QLatin1Char('/'))) continue;
+
+        const QString binary = path.mid(9);
+        if (binary.isEmpty()) continue;
+        if (binary.compare(packageId, Qt::CaseInsensitive) == 0) return QProcess::startDetached(path);
+        if (fallback.isEmpty()) fallback = path;
+    }
+
+    if (!fallback.isEmpty()) return QProcess::startDetached(fallback);
     return QProcess::startDetached(packageId);
 }

--- a/src/marketplace/plugins/pacmanplugin.cpp
+++ b/src/marketplace/plugins/pacmanplugin.cpp
@@ -235,6 +235,23 @@ bool PacmanPlugin::uninstall(const QString& packageId, const QVariantMap& option
     return result.succeeded();
 }
 
+bool PacmanPlugin::update(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
+    Q_UNUSED(options);
+    if (!isAvailable()) return false;
+
+    const astra::ProcessResult result = astra::runProcessStreaming(
+        QStringLiteral("pkexec"),
+        {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm"), packageId},
+        [&progressCb](const QString& line) {
+            if (progressCb) progressCb(50, line);
+        });
+
+    if (progressCb && !result.started) {
+        progressCb(0, QStringLiteral("Could not start pkexec"));
+    }
+    return result.succeeded();
+}
+
 bool PacmanPlugin::launch(const QString& packageId) {
     if (!isAvailable()) return false;
 

--- a/src/marketplace/plugins/pacmanplugin.hpp
+++ b/src/marketplace/plugins/pacmanplugin.hpp
@@ -25,6 +25,7 @@ public:
 
     bool install(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool uninstall(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
+    bool update(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
 
     static QVariantList parseSearchOutput(const QString& output);

--- a/src/marketplace/plugins/pacmanplugin.hpp
+++ b/src/marketplace/plugins/pacmanplugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "packageplugin.hpp"
+#include <QSet>
 #include <QSettings>
 
 class PacmanPlugin : public IPackagePlugin {
@@ -25,6 +26,12 @@ public:
     bool install(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool uninstall(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
+
+    static QVariantList parseSearchOutput(const QString& output);
+    static QSet<QString> parseForeignOutput(const QString& output);
+    static QVariantList parseInstalledOutput(const QString& output, const QSet<QString>& foreign);
+    static QVariantList parseUpdatesOutput(const QString& output);
+    static QVariantMap parseInfoOutput(const QString& output, const QString& packageId);
 
 private:
     bool m_enabled{true};

--- a/tests/tst_parsers.cpp
+++ b/tests/tst_parsers.cpp
@@ -1,0 +1,191 @@
+#include <QTest>
+#include <QElapsedTimer>
+#include <QSet>
+
+#include "pluginprocess.hpp"
+#include "flatpakplugin.hpp"
+#include "pacmanplugin.hpp"
+
+class TestParsers : public QObject {
+    Q_OBJECT
+
+private slots:
+    void pacmanSearchOutputIsParsed();
+    void pacmanSearchKeepsEveryEntry();
+    void pacmanInstalledSkipsForeignPackages();
+    void pacmanInstalledIsNotTruncated();
+    void pacmanUpdatesAreParsed();
+    void pacmanInfoParsesWrappedFields();
+    void pacmanInfoIgnoresEmptyValues();
+    void flatpakInstalledUsesColumns();
+    void flatpakInstalledFallsBackToAppId();
+    void flatpakUpdatesAreParsed();
+    void processReportsExitCode();
+    void processRunsWithParsableLocale();
+    void processStopsAtTimeout();
+    void processStreamsLinesSplitByCarriageReturn();
+};
+
+void TestParsers::pacmanSearchOutputIsParsed() {
+    const QString output = QStringLiteral(
+        "extra/vlc 3.0.21-10 [installed]\n"
+        "    Free and open source cross-platform multimedia player\n"
+        "multilib/lib32-vlc 3.0.21-1\n"
+        "    32-bit libraries\n");
+
+    const QVariantList results = PacmanPlugin::parseSearchOutput(output);
+    QCOMPARE(results.size(), 2);
+
+    const QVariantMap first = results.first().toMap();
+    QCOMPARE(first.value(QStringLiteral("id")).toString(), QStringLiteral("vlc"));
+    QCOMPARE(first.value(QStringLiteral("version")).toString(), QStringLiteral("3.0.21-10"));
+    QCOMPARE(first.value(QStringLiteral("repository")).toString(), QStringLiteral("extra"));
+    QCOMPARE(first.value(QStringLiteral("summary")).toString(), QStringLiteral("Free and open source cross-platform multimedia player"));
+    QVERIFY(first.value(QStringLiteral("isInstalled")).toBool());
+
+    const QVariantMap second = results.last().toMap();
+    QCOMPARE(second.value(QStringLiteral("id")).toString(), QStringLiteral("lib32-vlc"));
+    QCOMPARE(second.value(QStringLiteral("repository")).toString(), QStringLiteral("multilib"));
+    QVERIFY(!second.value(QStringLiteral("isInstalled")).toBool());
+}
+
+void TestParsers::pacmanSearchKeepsEveryEntry() {
+    QString output;
+    for (int i = 0; i < 400; ++i) {
+        output += QStringLiteral("extra/package-%1 1.0-1\n    summary %1\n").arg(i);
+    }
+    QCOMPARE(PacmanPlugin::parseSearchOutput(output).size(), 400);
+}
+
+void TestParsers::pacmanInstalledSkipsForeignPackages() {
+    const QString output = QStringLiteral("bash 5.3.15-1\nastramarket-git 1.1.0.r0-1\nvlc 3.0.21-10\n");
+    const QSet<QString> foreign = PacmanPlugin::parseForeignOutput(QStringLiteral("astramarket-git 1.1.0.r0-1\n"));
+
+    const QVariantList results = PacmanPlugin::parseInstalledOutput(output, foreign);
+    QCOMPARE(results.size(), 2);
+    QCOMPARE(results.first().toMap().value(QStringLiteral("id")).toString(), QStringLiteral("bash"));
+    QCOMPARE(results.first().toMap().value(QStringLiteral("version")).toString(), QStringLiteral("5.3.15-1"));
+    QVERIFY(results.first().toMap().value(QStringLiteral("isInstalled")).toBool());
+}
+
+void TestParsers::pacmanInstalledIsNotTruncated() {
+    QString output;
+    for (int i = 0; i < 512; ++i) {
+        output += QStringLiteral("package-%1 1.0-1\n").arg(i);
+    }
+    QCOMPARE(PacmanPlugin::parseInstalledOutput(output, {}).size(), 512);
+}
+
+void TestParsers::pacmanUpdatesAreParsed() {
+    const QString output = QStringLiteral("linux 7.1.7.arch1-1 -> 7.1.8.arch1-3\nvlc 3.0.21-9 -> 3.0.21-10\n");
+
+    const QVariantList results = PacmanPlugin::parseUpdatesOutput(output);
+    QCOMPARE(results.size(), 2);
+    QCOMPARE(results.first().toMap().value(QStringLiteral("id")).toString(), QStringLiteral("linux"));
+    QCOMPARE(results.first().toMap().value(QStringLiteral("version")).toString(), QStringLiteral("7.1.7.arch1-1 -> 7.1.8.arch1-3"));
+}
+
+void TestParsers::pacmanInfoParsesWrappedFields() {
+    const QString output = QStringLiteral(
+        "Repository      : core\n"
+        "Name            : linux\n"
+        "Version         : 7.1.8.arch1-3\n"
+        "Description     : The Linux kernel\n"
+        "URL             : https://github.com/archlinux/linux\n"
+        "Licenses        : GPL-2.0-only\n"
+        "Optional Deps   : linux-headers: headers and scripts\n"
+        "                  linux-firmware: firmware images\n"
+        "Installed Size  : 147.72 MiB\n"
+        "Packager        : Frederik Schwan <freswa@archlinux.org>\n");
+
+    const QVariantMap details = PacmanPlugin::parseInfoOutput(output, QStringLiteral("linux"));
+    QCOMPARE(details.value(QStringLiteral("version")).toString(), QStringLiteral("7.1.8.arch1-3"));
+    QCOMPARE(details.value(QStringLiteral("summary")).toString(), QStringLiteral("The Linux kernel"));
+    QCOMPARE(details.value(QStringLiteral("homepage")).toString(), QStringLiteral("https://github.com/archlinux/linux"));
+    QCOMPARE(details.value(QStringLiteral("license")).toString(), QStringLiteral("GPL-2.0-only"));
+    QCOMPARE(details.value(QStringLiteral("developer")).toString(), QStringLiteral("Frederik Schwan <freswa@archlinux.org>"));
+    QCOMPARE(details.value(QStringLiteral("repository")).toString(), QStringLiteral("core"));
+    QCOMPARE(details.value(QStringLiteral("size")).toString(), QStringLiteral("147.72 MiB"));
+}
+
+void TestParsers::pacmanInfoIgnoresEmptyValues() {
+    const QString output = QStringLiteral(
+        "Name            : bash\n"
+        "Version         : 5.3.15-1\n"
+        "Groups          : None\n"
+        "URL             : None\n");
+
+    const QVariantMap details = PacmanPlugin::parseInfoOutput(output, QStringLiteral("bash"));
+    QVERIFY(!details.contains(QStringLiteral("homepage")));
+    QCOMPARE(details.value(QStringLiteral("name")).toString(), QStringLiteral("bash"));
+}
+
+void TestParsers::flatpakInstalledUsesColumns() {
+    const QString output = QStringLiteral("org.videolan.VLC\tVLC\t3.0.21\t312.4 MB\ncom.spotify.Client\tSpotify\t1.2.52\t280.0 MB\n");
+
+    const QVariantList results = FlatpakPlugin::parseInstalledOutput(output, QStringLiteral("system"));
+    QCOMPARE(results.size(), 2);
+
+    const QVariantMap first = results.first().toMap();
+    QCOMPARE(first.value(QStringLiteral("id")).toString(), QStringLiteral("org.videolan.VLC"));
+    QCOMPARE(first.value(QStringLiteral("name")).toString(), QStringLiteral("VLC"));
+    QCOMPARE(first.value(QStringLiteral("version")).toString(), QStringLiteral("3.0.21"));
+    QCOMPARE(first.value(QStringLiteral("size")).toString(), QStringLiteral("312.4 MB"));
+    QCOMPARE(first.value(QStringLiteral("scope")).toString(), QStringLiteral("system"));
+}
+
+void TestParsers::flatpakInstalledFallsBackToAppId() {
+    const QVariantList results = FlatpakPlugin::parseInstalledOutput(QStringLiteral("org.gnome.Platform\t\t\t\n"), QStringLiteral("user"));
+    QCOMPARE(results.size(), 1);
+    QCOMPARE(results.first().toMap().value(QStringLiteral("name")).toString(), QStringLiteral("org.gnome.Platform"));
+    QCOMPARE(results.first().toMap().value(QStringLiteral("version")).toString(), QStringLiteral("latest"));
+}
+
+void TestParsers::flatpakUpdatesAreParsed() {
+    const QVariantList results = FlatpakPlugin::parseUpdatesOutput(QStringLiteral("org.freedesktop.Platform.GL.default\tMesa\t26.1.5\n"));
+    QCOMPARE(results.size(), 1);
+    QCOMPARE(results.first().toMap().value(QStringLiteral("name")).toString(), QStringLiteral("Mesa"));
+    QCOMPARE(results.first().toMap().value(QStringLiteral("backend")).toString(), QStringLiteral("Flatpak"));
+}
+
+void TestParsers::processReportsExitCode() {
+    const astra::ProcessResult ok = astra::runProcess(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), QStringLiteral("printf hello")});
+    QVERIFY(ok.succeeded());
+    QCOMPARE(ok.output, QStringLiteral("hello"));
+
+    const astra::ProcessResult failed = astra::runProcess(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), QStringLiteral("exit 3")});
+    QVERIFY(!failed.succeeded());
+    QCOMPARE(failed.exitCode, 3);
+
+    const astra::ProcessResult missing = astra::runProcess(QStringLiteral("astra-does-not-exist"), {});
+    QVERIFY(!missing.started);
+    QVERIFY(!missing.succeeded());
+}
+
+void TestParsers::processRunsWithParsableLocale() {
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), QStringLiteral("printf '%s' \"$LC_ALL\"")});
+    QCOMPARE(result.output, QStringLiteral("C.UTF-8"));
+}
+
+void TestParsers::processStopsAtTimeout() {
+    QElapsedTimer timer;
+    timer.start();
+    const astra::ProcessResult result = astra::runProcess(QStringLiteral("/bin/sh"), {QStringLiteral("-c"), QStringLiteral("sleep 10")}, 500);
+    QVERIFY(result.timedOut);
+    QVERIFY(!result.succeeded());
+    QVERIFY(timer.elapsed() < 5000);
+}
+
+void TestParsers::processStreamsLinesSplitByCarriageReturn() {
+    QStringList lines;
+    const astra::ProcessResult result = astra::runProcessStreaming(
+        QStringLiteral("/bin/sh"),
+        {QStringLiteral("-c"), QStringLiteral("printf 'first\\rsecond\\nthird'")},
+        [&lines](const QString& line) { lines.append(line); });
+
+    QVERIFY(result.succeeded());
+    QCOMPARE(lines, QStringList({QStringLiteral("first"), QStringLiteral("second"), QStringLiteral("third")}));
+}
+
+QTEST_GUILESS_MAIN(TestParsers)
+#include "tst_parsers.moc"


### PR DESCRIPTION
> Builds on #4, #6, #7 and #8 — the diff contains those commits until they are merged. This PR is the last commit (`feat(cli): …`).

## Problems

**1. The CLI cannot apply updates.** `--help` says `update  Check for or perform updates`, but `handleUpdate()` only prints the list, and `upgrade` is an alias for it. There is no way to update anything without the GUI.

**2. Colours are written even when not writing to a terminal.**

```
$ astra search vlc | head -3
^[[2mSearching for "vlc"...^[[0m
```

Every redirect or pipe gets escape sequences, and there is no `--no-color`; `NO_COLOR` is ignored.

**3. No machine readable output.** Everything is a fixed-width table truncated to the terminal layout (`id.left(31) + "..."`), so scripts cannot use the CLI.

**4. The source is guessed from the package id.**

```cpp
source = packageId.contains('.') ? "Flatpak" : "Pacman";
```

AUR is never selected, so `astra install yay-bin` tries pacman and fails; `astra remove` on a Flatpak app installed in the system scope hits the wrong backend, and removing something that is not installed produces a backend error rather than a clear message.

## Change

- `astra update` lists, `astra upgrade` applies — all updates (Flatpak, then Caelestia or pacman, the same sequence the GUI's "Update All" runs) or a single package via `IPackagePlugin::update()`. The system update body moved from the `QtConcurrent` lambda into `PackageManager::runSystemUpdate()` so the GUI and the CLI share it, and it now reports real success instead of always returning true.
- Colour is emitted only when stdout is a terminal, and `NO_COLOR` / `--no-color` disable it.
- `--json` for `search`, `list`, `update`, `info` and `sources` prints the full records instead of the truncated table.
- Option parsing happens once (`--source`, `--scope`, `--json`, `--no-color`) instead of being repeated in each handler; `list` also honours `--source`.
- Source resolution looks the package up: exactly one source that provides it is used, several sources are listed for the user to choose from (info just picks the first and says so), and `remove`/`upgrade` resolve to the source the package is actually installed from — "not installed" is reported as such.
- Bash, zsh and fish completions in `assets/completions/`, installed to the standard locations.
- README documents `upgrade`, `--json`, the colour rules and the completions.

## Testing

```
$ astra search vlc | cat -v          # no escape sequences
$ script -qec "astra --version"      # coloured on a pty, plain with NO_COLOR=1
$ astra search vlc --source Pacman --json | head
[ { "backend": "Pacman", "id": "vlc", … } ]
$ astra info yay
Using Pacman, also available from AUR (--source picks another)
$ astra info yay --source AUR        # AUR record
$ astra remove definitely-not-installed-xyz   # "is not installed", rc=1
$ astra upgrade                      # with stub flatpak/pacman/caelestia on PATH:
flatpak update -y
caelestia update --noconfirm
```

Exit codes: 0 on success, 1 for a failed operation or invalid arguments (`remove` of a missing package, empty search, unknown command all return 1).

Completions: the bash function was sourced and driven directly (`astra se` → `search`, `--source` → the four sources, `--scope` → `user system`); the fish file passes `fish -n`; all three install to `share/bash-completion/completions`, `share/zsh/site-functions`, `share/fish/vendor_completions.d`. `ctest` passes and the GUI is unaffected.