### PR TITLE
feat(aur): show the PKGBUILD before installing

### DIFF
--- a/qml/qs/modules/astra/pages/AppDetailPage.qml
+++ b/qml/qs/modules/astra/pages/AppDetailPage.qml
@@ -39,6 +39,9 @@ PageBase {
     property bool requiredByExpanded: true
 
     property bool descExpanded: false
+    property bool buildScriptExpanded: false
+    property bool buildScriptLoading: false
+    property string buildScript: ""
     property bool isLoadingDetails: true
     property string selectedScope: (root.appData && root.appData.scope) ? root.appData.scope : "user"
 
@@ -52,6 +55,15 @@ PageBase {
         }
 
         return text.replace(/\n\n/g, "<br><br>").replace(/\n/g, "<br>");
+    }
+
+    function toggleBuildScript(): void {
+        root.buildScriptExpanded = !root.buildScriptExpanded;
+
+        if (root.buildScriptExpanded && root.buildScript.length === 0 && !root.buildScriptLoading && root.appData) {
+            root.buildScriptLoading = true;
+            PackageManager.fetchBuildScriptAsync(root.appData.id || "");
+        }
     }
 
     function loadDetails(): void {
@@ -93,6 +105,13 @@ PageBase {
                     root.isInstalled = PackageManager.isPackageInstalled(root.appData.backend || "", root.appData.id);
                     root.loadDetails();
                 }
+            }
+            function onBuildScriptReady(packageId, script): void {
+                if (!root.appData || packageId !== root.appData.id)
+                    return;
+
+                root.buildScriptLoading = false;
+                root.buildScript = script;
             }
         }
 
@@ -956,6 +975,116 @@ PageBase {
                                         color: Colours.palette.m3onSurface
                                     }
                                 }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        StyledRect {
+            Layout.fillWidth: true
+            visible: root.appData && root.appData.backend === "AUR"
+            implicitHeight: buildScriptColumn.implicitHeight + Tokens.padding.medium * 2
+            radius: Tokens.rounding.large
+            color: Colours.tPalette.m3surfaceContainer
+
+            ColumnLayout {
+                id: buildScriptColumn
+
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                spacing: Tokens.padding.small
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Tokens.padding.small
+
+                    MaterialIcon {
+                        text: "terminal"
+                        fontStyle: Tokens.font.icon.medium
+                        color: Colours.palette.m3primary
+                    }
+
+                    StyledText {
+                        text: qsTr("PKGBUILD")
+                        font: Tokens.font.title.large
+                        color: Colours.palette.m3onSurface
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    IconButton {
+                        type: ButtonBase.Text
+                        icon: "expand_more"
+                        rotation: root.buildScriptExpanded ? 180 : 0
+
+                        Behavior on rotation {
+                            Anim {}
+                        }
+
+                        onClicked: root.toggleBuildScript()
+                    }
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    visible: !root.buildScriptExpanded
+                    text: qsTr("AUR packages are built from a script that runs on your machine. Review it before installing.")
+                    font: Tokens.font.body.small
+                    color: Colours.palette.m3onSurfaceVariant
+                    wrapMode: Text.WordWrap
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                    implicitHeight: root.buildScriptExpanded ? 320 : 0
+                    clip: true
+
+                    Behavior on implicitHeight {
+                        NumberAnimation {
+                            duration: 250
+                            easing.type: Easing.OutCubic
+                        }
+                    }
+
+                    StyledRect {
+                        anchors.fill: parent
+                        radius: Tokens.rounding.medium
+                        color: Colours.palette.m3surfaceContainerLow
+
+                        LoadingIndicator {
+                            anchors.centerIn: parent
+                            visible: root.buildScriptLoading
+                            implicitSize: 32
+                            color: Colours.palette.m3primary
+                        }
+
+                        StyledText {
+                            anchors.centerIn: parent
+                            visible: !root.buildScriptLoading && root.buildScript.length === 0
+                            text: qsTr("The build script could not be loaded.")
+                            font: Tokens.font.body.small
+                            color: Colours.palette.m3onSurfaceVariant
+                        }
+
+                        StyledFlickable {
+                            anchors.fill: parent
+                            anchors.margins: Tokens.padding.small
+                            visible: root.buildScript.length > 0
+                            contentWidth: buildScriptText.implicitWidth
+                            contentHeight: buildScriptText.implicitHeight
+                            clip: true
+
+                            Text {
+                                id: buildScriptText
+
+                                text: root.buildScript
+                                font.family: "Monospace, DejaVu Sans Mono, Courier New"
+                                font.pixelSize: 12
+                                color: Colours.palette.m3onSurface
+                                textFormat: Text.PlainText
+                                wrapMode: Text.NoWrap
                             }
                         }
                     }

--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -648,6 +648,30 @@ void PackageManager::fetchCollectionAsync(const QString& collection, int limit) 
     }));
 }
 
+void PackageManager::fetchBuildScriptAsync(const QString& packageId) {
+    if (packageId.isEmpty() || !m_aurPlugin) return;
+
+    if (m_buildScripts.contains(packageId)) {
+        const QString cached = m_buildScripts.value(packageId);
+        QMetaObject::invokeMethod(this, [this, packageId, cached] {
+            emit buildScriptReady(packageId, cached);
+        }, Qt::QueuedConnection);
+        return;
+    }
+
+    auto* watcher = new QFutureWatcher<QString>(this);
+    connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher, packageId] {
+        const QString script = watcher->result();
+        watcher->deleteLater();
+        if (!script.isEmpty()) m_buildScripts.insert(packageId, script);
+        emit buildScriptReady(packageId, script);
+    });
+
+    watcher->setFuture(QtConcurrent::run(&m_pluginPool, [this, packageId] {
+        return m_aurPlugin->getBuildScript(packageId);
+    }));
+}
+
 QVariantList PackageManager::checkForUpdates() {
     QVariantList results;
     const bool useCaelestia = useCaelestiaUpdate();

--- a/src/marketplace/packagemanager.hpp
+++ b/src/marketplace/packagemanager.hpp
@@ -94,6 +94,7 @@ public:
     Q_INVOKABLE QVariantMap getPackageDetails(const QString& packageId, const QString& backend = QString());
     Q_INVOKABLE void fetchPackageDetailsAsync(const QString& packageId, const QString& backend = QString());
     Q_INVOKABLE void fetchCollectionAsync(const QString& collection, int limit = 12);
+    Q_INVOKABLE void fetchBuildScriptAsync(const QString& packageId);
     Q_INVOKABLE QVariantList checkForUpdates();
     Q_INVOKABLE void checkForUpdatesAsync();
     Q_INVOKABLE void updateAllPackages();
@@ -123,6 +124,7 @@ signals:
     void updatesCompleted(const QVariantList& updates);
     void packageDetailsReady(const QVariantMap& details);
     void collectionReady(const QString& collection, const QVariantList& apps);
+    void buildScriptReady(const QString& packageId, const QString& script);
 
 private:
     void setBusy(bool busy);
@@ -142,6 +144,7 @@ private:
 
     QThreadPool m_pluginPool;
     QHash<QString, QVariantList> m_collections;
+    QHash<QString, QString> m_buildScripts;
     QSet<QString> m_pendingCollections;
 
     quint64 m_searchSequence{0};

--- a/src/marketplace/plugins/aurplugin.cpp
+++ b/src/marketplace/plugins/aurplugin.cpp
@@ -14,6 +14,7 @@
 #include <QNetworkReply>
 #include <QEventLoop>
 #include <QUrl>
+#include <QUrlQuery>
 
 namespace {
 constexpr int kQueryTimeoutMs = 15000;
@@ -150,6 +151,32 @@ QVariantList AurPlugin::search(const QString& query, const QVariantMap& options)
     }
     reply->deleteLater();
     return results;
+}
+
+QString AurPlugin::getBuildScript(const QString& packageId) {
+    if (packageId.isEmpty()) return QString();
+
+    QNetworkAccessManager manager;
+    QUrl url(QStringLiteral("https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD"));
+    QUrlQuery query;
+    query.addQueryItem(QStringLiteral("h"), packageId);
+    url.setQuery(query);
+
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
+    request.setTransferTimeout(kNetworkTimeoutMs);
+
+    QEventLoop loop;
+    QNetworkReply* reply = manager.get(request);
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    QString script;
+    if (reply->error() == QNetworkReply::NoError) {
+        script = QString::fromUtf8(reply->readAll());
+    }
+    reply->deleteLater();
+    return script;
 }
 
 QVariantList AurPlugin::parseForeignOutput(const QString& output) {

--- a/src/marketplace/plugins/aurplugin.hpp
+++ b/src/marketplace/plugins/aurplugin.hpp
@@ -31,6 +31,8 @@ public:
     bool update(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
 
+    QString getBuildScript(const QString& packageId);
+
     static QVariantList parseForeignOutput(const QString& output);
     static QVariantList parseUpdatesOutput(const QString& output);
 


### PR DESCRIPTION
## Problem

Installing an AUR package runs `PKGBUILD` — arbitrary shell code from a third party — on the user's machine, with `--noconfirm`. The app gives no way to see that script first; the only hint that AUR packages differ from repository packages is the "AUR" badge.

## Change

For AUR packages the detail page gains a collapsible **PKGBUILD** card:

- Collapsed it explains why it matters ("AUR packages are built from a script that runs on your machine. Review it before installing.").
- On first expand it fetches `https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=<pkg>` off the UI thread and shows the script monospaced in a scrollable box, using the same styling as the log view.
- The result is cached for the session; a failed request shows a short message instead of an empty box.

`AurPlugin::getBuildScript()` does the request with the existing timeout and user agent, `PackageManager::fetchBuildScriptAsync()` runs it on the plugin thread pool and emits `buildScriptReady(packageId, script)`.

## Testing

Verified in the running app for `yay-bin`: the card appears only for AUR packages, expands with the real script (`pkgname=yay-bin`, `pkgver=13.0.1`, `depends=('pacman>6.1' 'git')` …), scrolls horizontally for long lines, and collapses again. Flatpak, Pacman and AppImage detail pages are unchanged. `ctest` passes.