### PR TITLE
feat(flatpak): show real sizes, publisher and sandbox permissions

### DIFF
--- a/qml/qs/modules/astra/pages/AppDetailPage.qml
+++ b/qml/qs/modules/astra/pages/AppDetailPage.qml
@@ -24,6 +24,11 @@ PageBase {
     readonly property string detailLicenses: (root.infoMap && (root.infoMap.licenses || root.infoMap.license)) ? (root.infoMap.licenses || root.infoMap.license) : ""
     readonly property string detailInstalledSize: (root.infoMap && (root.infoMap.installedSize || root.infoMap.size)) ? (root.infoMap.installedSize || root.infoMap.size) : ""
     readonly property string detailDownloadSize: (root.infoMap && root.infoMap.downloadSize) ? root.infoMap.downloadSize : ""
+    readonly property var permissionList: (root.infoMap && root.infoMap.permissions) ? root.infoMap.permissions : []
+    readonly property bool detailVerified: !!(root.infoMap && root.infoMap.verified)
+    readonly property int detailContentFlags: (root.infoMap && root.infoMap.contentRatingFlags !== undefined) ? root.infoMap.contentRatingFlags : -1
+    readonly property real detailInstalls: (root.infoMap && root.infoMap.installsTotal) ? root.infoMap.installsTotal : 0
+    readonly property real detailInstallsLastMonth: (root.infoMap && root.infoMap.installsLastMonth) ? root.infoMap.installsLastMonth : 0
     readonly property string detailBuildDate: (root.infoMap && root.infoMap.buildDate) ? root.infoMap.buildDate : ""
     readonly property string detailInstallReason: (root.infoMap && root.infoMap.installReason) ? root.infoMap.installReason : ""
     readonly property string detailProvides: (root.infoMap && root.infoMap.provides) ? root.infoMap.provides : ""
@@ -55,6 +60,14 @@ PageBase {
         }
 
         return text.replace(/\n\n/g, "<br><br>").replace(/\n/g, "<br>");
+    }
+
+    function compactCount(value: real): string {
+        if (value >= 1000000)
+            return (value / 1000000).toFixed(1) + "M";
+        if (value >= 1000)
+            return Math.round(value / 1000) + "k";
+        return String(value);
     }
 
     function toggleBuildScript(): void {
@@ -219,36 +232,38 @@ PageBase {
                         text: "•"
                         font: Tokens.font.body.small
                         color: Colours.palette.m3onSurfaceVariant
-                        visible: root.appData && root.appData.backend === "Flatpak"
+                        visible: root.detailVerified
                     }
 
                     StyledText {
-                        text: qsTr("Official")
+                        text: qsTr("Verified")
                         font: Tokens.font.body.small
                         color: Colours.palette.m3onSurfaceVariant
-                        visible: root.appData && root.appData.backend === "Flatpak"
+                        visible: root.detailVerified
                     }
 
                     MaterialIcon {
                         text: "verified"
                         fontStyle: Tokens.font.icon.small
                         color: Colours.palette.m3primary
-                        visible: root.appData && root.appData.backend === "Flatpak"
+                        visible: root.detailVerified
                     }
                 }
 
                 RowLayout {
                     spacing: Tokens.padding.extraSmall
-                    visible: root.appData && root.appData.backend === "Flatpak"
+                    visible: root.detailInstalls > 0
 
-                    StyledText {
-                        text: "★★★★★"
-                        font: Tokens.font.body.small
-                        color: "#f59e0b"
+                    MaterialIcon {
+                        text: "download"
+                        fontStyle: Tokens.font.icon.small
+                        color: Colours.palette.m3onSurfaceVariant
                     }
 
                     StyledText {
-                        text: "4.9 (1.2k ratings)"
+                        text: root.detailInstallsLastMonth > 0
+                            ? qsTr("%1 installs, %2 in the last month").arg(root.compactCount(root.detailInstalls)).arg(root.compactCount(root.detailInstallsLastMonth))
+                            : qsTr("%1 installs").arg(root.compactCount(root.detailInstalls))
                         font: Tokens.font.body.small
                         color: Colours.palette.m3onSurfaceVariant
                     }
@@ -457,7 +472,7 @@ PageBase {
                         Layout.alignment: Qt.AlignHCenter
                     }
                     StyledText {
-                        text: "235.5 MB"
+                        text: root.detailDownloadSize !== "" ? root.detailDownloadSize : "-"
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurface
                         Layout.alignment: Qt.AlignHCenter
@@ -481,19 +496,19 @@ PageBase {
                     anchors.centerIn: parent
                     spacing: 4
                     MaterialIcon {
-                        text: "security"
+                        text: root.detailVerified ? "verified" : "groups"
                         fontStyle: Tokens.font.icon.medium
                         color: Colours.palette.m3primary
                         Layout.alignment: Qt.AlignHCenter
                     }
                     StyledText {
-                        text: qsTr("Verified Safe")
+                        text: root.detailVerified ? qsTr("Verified") : qsTr("Community")
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurface
                         Layout.alignment: Qt.AlignHCenter
                     }
                     StyledText {
-                        text: qsTr("Security Status")
+                        text: qsTr("Publisher")
                         font: Tokens.font.label.small
                         color: Colours.palette.m3onSurfaceVariant
                         Layout.alignment: Qt.AlignHCenter
@@ -511,19 +526,19 @@ PageBase {
                     anchors.centerIn: parent
                     spacing: 4
                     MaterialIcon {
-                        text: "computer"
+                        text: "hard_drive"
                         fontStyle: Tokens.font.icon.medium
                         color: Colours.palette.m3primary
                         Layout.alignment: Qt.AlignHCenter
                     }
                     StyledText {
-                        text: qsTr("Desktop")
+                        text: root.detailInstalledSize !== "" ? root.detailInstalledSize : (root.appData && root.appData.size ? root.appData.size : "-")
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurface
                         Layout.alignment: Qt.AlignHCenter
                     }
                     StyledText {
-                        text: qsTr("Platform")
+                        text: qsTr("Installed Size")
                         font: Tokens.font.label.small
                         color: Colours.palette.m3onSurfaceVariant
                         Layout.alignment: Qt.AlignHCenter
@@ -550,7 +565,7 @@ PageBase {
                         Layout.alignment: Qt.AlignHCenter
                     }
                     StyledText {
-                        text: qsTr("Everyone")
+                        text: root.detailContentFlags < 0 ? "-" : (root.detailContentFlags === 0 ? qsTr("Everyone") : qsTr("%1 flagged").arg(root.detailContentFlags))
                         font: Tokens.font.label.large
                         color: Colours.palette.m3onSurface
                         Layout.alignment: Qt.AlignHCenter
@@ -625,6 +640,74 @@ PageBase {
                         Anim {}
                     }
                     onClicked: root.descExpanded = !root.descExpanded
+                }
+            }
+        }
+
+        StyledRect {
+            Layout.fillWidth: true
+            visible: root.permissionList.length > 0
+            implicitHeight: permissionsColumn.implicitHeight + Tokens.padding.medium * 2
+            radius: Tokens.rounding.large
+            color: Colours.tPalette.m3surfaceContainer
+
+            ColumnLayout {
+                id: permissionsColumn
+
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                spacing: Tokens.padding.small
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Tokens.padding.small
+
+                    MaterialIcon {
+                        text: "shield"
+                        fontStyle: Tokens.font.icon.medium
+                        color: Colours.palette.m3primary
+                    }
+
+                    StyledText {
+                        text: qsTr("Permissions")
+                        font: Tokens.font.title.large
+                        color: Colours.palette.m3onSurface
+                    }
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("What this application is allowed to access outside its sandbox.")
+                    font: Tokens.font.body.small
+                    color: Colours.palette.m3onSurfaceVariant
+                    wrapMode: Text.WordWrap
+                }
+
+                Repeater {
+                    model: root.permissionList
+
+                    RowLayout {
+                        id: permissionRow
+
+                        required property var modelData
+
+                        Layout.fillWidth: true
+                        spacing: Tokens.padding.small
+
+                        MaterialIcon {
+                            text: permissionRow.modelData.icon
+                            fontStyle: Tokens.font.icon.small
+                            color: permissionRow.modelData.sensitive ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                        }
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: permissionRow.modelData.label
+                            font: Tokens.font.body.medium
+                            color: permissionRow.modelData.sensitive ? Colours.palette.m3error : Colours.palette.m3onSurface
+                            elide: Text.ElideRight
+                        }
+                    }
                 }
             }
         }

--- a/src/marketplace/plugins/flatpakplugin.cpp
+++ b/src/marketplace/plugins/flatpakplugin.cpp
@@ -342,6 +342,159 @@ QVariantList FlatpakPlugin::getUpdates() {
     return results;
 }
 
+QString FlatpakPlugin::formatBytes(qint64 bytes) {
+    if (bytes <= 0) return QString();
+
+    static const QStringList units{QStringLiteral("KB"), QStringLiteral("MB"), QStringLiteral("GB")};
+    double value = bytes / 1024.0;
+    int unit = 0;
+    while (value >= 1024.0 && unit + 1 < units.size()) {
+        value /= 1024.0;
+        ++unit;
+    }
+    return QString::number(value, 'f', value < 10 ? 1 : 0) + QLatin1Char(' ') + units.at(unit);
+}
+
+namespace {
+
+QByteArray httpGet(const QUrl& url, int timeoutMs) {
+    QNetworkAccessManager manager;
+
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("AstraMarket/1.0"));
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    request.setTransferTimeout(timeoutMs);
+
+    QEventLoop loop;
+    QNetworkReply* reply = manager.get(request);
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    QByteArray payload;
+    if (reply->error() == QNetworkReply::NoError) payload = reply->readAll();
+    reply->deleteLater();
+    return payload;
+}
+
+int flaggedContentCategories(const QJsonObject& details) {
+    for (const QString& locale : details.keys()) {
+        const QJsonArray categories = details.value(locale).toObject().value(QStringLiteral("categories")).toArray();
+        if (categories.isEmpty()) continue;
+
+        int flagged = 0;
+        for (const QJsonValue& value : categories) {
+            if (value.toObject().value(QStringLiteral("level")).toString() != QStringLiteral("none")) ++flagged;
+        }
+        return flagged;
+    }
+    return -1;
+}
+
+void appendPermission(QVariantList& entries, const QString& label, const QString& icon, bool sensitive) {
+    for (const QVariant& value : entries) {
+        if (value.toMap().value(QStringLiteral("label")).toString() == label) return;
+    }
+
+    QVariantMap entry;
+    entry[QStringLiteral("label")] = label;
+    entry[QStringLiteral("icon")] = icon;
+    entry[QStringLiteral("sensitive")] = sensitive;
+    entries.append(entry);
+}
+
+void appendSharedPermission(QVariantList& entries, const QString& value) {
+    if (value == QStringLiteral("network")) appendPermission(entries, QObject::tr("Network access"), QStringLiteral("public"), false);
+}
+
+void appendSocketPermission(QVariantList& entries, const QString& value) {
+    if (value == QStringLiteral("x11")) appendPermission(entries, QObject::tr("Legacy X11 windowing system"), QStringLiteral("desktop_windows"), true);
+    else if (value == QStringLiteral("wayland")) appendPermission(entries, QObject::tr("Wayland windowing system"), QStringLiteral("desktop_windows"), false);
+    else if (value == QStringLiteral("fallback-x11")) appendPermission(entries, QObject::tr("X11 windowing system as fallback"), QStringLiteral("desktop_windows"), false);
+    else if (value == QStringLiteral("pulseaudio")) appendPermission(entries, QObject::tr("Audio"), QStringLiteral("volume_up"), false);
+    else if (value == QStringLiteral("session-bus")) appendPermission(entries, QObject::tr("Full session bus access"), QStringLiteral("hub"), true);
+    else if (value == QStringLiteral("system-bus")) appendPermission(entries, QObject::tr("Full system bus access"), QStringLiteral("hub"), true);
+    else if (value == QStringLiteral("ssh-auth")) appendPermission(entries, QObject::tr("SSH agent"), QStringLiteral("key"), true);
+    else if (value == QStringLiteral("gpg-agent")) appendPermission(entries, QObject::tr("GPG agent"), QStringLiteral("key"), true);
+    else if (value == QStringLiteral("cups")) appendPermission(entries, QObject::tr("Printing"), QStringLiteral("print"), false);
+}
+
+void appendDevicePermission(QVariantList& entries, const QString& value) {
+    if (value == QStringLiteral("all")) appendPermission(entries, QObject::tr("All devices"), QStringLiteral("devices_other"), true);
+    else if (value == QStringLiteral("dri")) appendPermission(entries, QObject::tr("GPU acceleration"), QStringLiteral("memory"), false);
+    else if (value == QStringLiteral("input")) appendPermission(entries, QObject::tr("Input devices"), QStringLiteral("keyboard"), false);
+    else if (value == QStringLiteral("kvm")) appendPermission(entries, QObject::tr("Virtual machines"), QStringLiteral("developer_board"), true);
+    else if (value == QStringLiteral("shm")) appendPermission(entries, QObject::tr("Shared memory"), QStringLiteral("memory"), false);
+}
+
+void appendFilesystemPermission(QVariantList& entries, const QString& value) {
+    QString path = value;
+    bool readOnly = false;
+    if (path.endsWith(QStringLiteral(":ro"))) {
+        path.chop(3);
+        readOnly = true;
+    } else if (path.endsWith(QStringLiteral(":rw")) || path.endsWith(QStringLiteral(":create"))) {
+        path = path.section(QLatin1Char(':'), 0, 0);
+    }
+
+    if (path == QStringLiteral("host")) {
+        appendPermission(entries, readOnly ? QObject::tr("All system files, read only") : QObject::tr("All system files"), QStringLiteral("folder_open"), !readOnly);
+    } else if (path == QStringLiteral("host-os")) {
+        appendPermission(entries, QObject::tr("System libraries and binaries"), QStringLiteral("folder_open"), true);
+    } else if (path == QStringLiteral("host-etc")) {
+        appendPermission(entries, QObject::tr("System configuration in /etc"), QStringLiteral("folder_open"), true);
+    } else if (path == QStringLiteral("home")) {
+        appendPermission(entries, readOnly ? QObject::tr("Your home folder, read only") : QObject::tr("Your home folder"), QStringLiteral("home"), !readOnly);
+    } else if (path.startsWith(QStringLiteral("xdg-"))) {
+        appendPermission(entries, QObject::tr("Folder: %1").arg(path.mid(4)), QStringLiteral("folder"), false);
+    } else if (!path.isEmpty()) {
+        appendPermission(entries, QObject::tr("Path: %1").arg(path), QStringLiteral("folder"), !readOnly && !path.startsWith(QLatin1Char('~')));
+    }
+}
+
+}
+
+QVariantList FlatpakPlugin::permissionEntries(const QJsonObject& permissions) {
+    QVariantList entries;
+
+    for (const QJsonValue& value : permissions.value(QStringLiteral("shared")).toArray()) {
+        appendSharedPermission(entries, value.toString());
+    }
+    for (const QJsonValue& value : permissions.value(QStringLiteral("sockets")).toArray()) {
+        appendSocketPermission(entries, value.toString());
+    }
+    for (const QJsonValue& value : permissions.value(QStringLiteral("devices")).toArray()) {
+        appendDevicePermission(entries, value.toString());
+    }
+    for (const QJsonValue& value : permissions.value(QStringLiteral("filesystems")).toArray()) {
+        appendFilesystemPermission(entries, value.toString());
+    }
+
+    return entries;
+}
+
+QVariantList FlatpakPlugin::parseLocalPermissions(const QString& output) {
+    QVariantList entries;
+
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    for (const QString& line : lines) {
+        const QString trimmed = line.trimmed();
+        const qsizetype separator = trimmed.indexOf(QLatin1Char('='));
+        if (separator <= 0) continue;
+
+        const QString key = trimmed.left(separator);
+        const QStringList values = trimmed.mid(separator + 1).split(QLatin1Char(';'), Qt::SkipEmptyParts);
+
+        for (const QString& value : values) {
+            if (key == QStringLiteral("shared")) appendSharedPermission(entries, value);
+            else if (key == QStringLiteral("sockets")) appendSocketPermission(entries, value);
+            else if (key == QStringLiteral("devices")) appendDevicePermission(entries, value);
+            else if (key == QStringLiteral("filesystems")) appendFilesystemPermission(entries, value);
+        }
+    }
+
+    return entries;
+}
+
 QVariantMap FlatpakPlugin::getDetails(const QString& packageId) {
     QVariantMap map;
     map[QStringLiteral("id")] = packageId;
@@ -401,9 +554,55 @@ QVariantMap FlatpakPlugin::getDetails(const QString& packageId) {
                 }
                 map[QStringLiteral("screenshots")] = shots;
             }
+
+            const int flagged = flaggedContentCategories(obj.value(QStringLiteral("content_rating_details")).toObject());
+            if (flagged >= 0) map[QStringLiteral("contentRatingFlags")] = flagged;
         }
     }
     reply->deleteLater();
+
+    const QJsonDocument summary = QJsonDocument::fromJson(
+        httpGet(QUrl(QStringLiteral("https://flathub.org/api/v2/summary/") + packageId), kDetailsTimeoutMs));
+    if (summary.isObject()) {
+        const QJsonObject root = summary.object();
+        const QString downloadSize = formatBytes(root.value(QStringLiteral("download_size")).toInteger());
+        const QString installedSize = formatBytes(root.value(QStringLiteral("installed_size")).toInteger());
+        if (!downloadSize.isEmpty()) map[QStringLiteral("downloadSize")] = downloadSize;
+        if (!installedSize.isEmpty()) map[QStringLiteral("installedSize")] = installedSize;
+
+        const QJsonObject metadata = root.value(QStringLiteral("metadata")).toObject();
+        const QVariantList permissions = permissionEntries(metadata.value(QStringLiteral("permissions")).toObject());
+        if (!permissions.isEmpty()) map[QStringLiteral("permissions")] = permissions;
+
+        const QString runtime = metadata.value(QStringLiteral("runtimeName")).toString();
+        if (!runtime.isEmpty()) map[QStringLiteral("runtime")] = runtime;
+    }
+
+    if (map.value(QStringLiteral("permissions")).toList().isEmpty()) {
+        const astra::ProcessResult local = astra::runProcess(
+            QStringLiteral("flatpak"), {QStringLiteral("info"), QStringLiteral("--show-permissions"), packageId}, kQueryTimeoutMs);
+        if (local.succeeded()) {
+            const QVariantList permissions = parseLocalPermissions(local.output);
+            if (!permissions.isEmpty()) map[QStringLiteral("permissions")] = permissions;
+        }
+    }
+
+    const QJsonDocument stats = QJsonDocument::fromJson(
+        httpGet(QUrl(QStringLiteral("https://flathub.org/api/v2/stats/") + packageId), kSearchTimeoutMs));
+    if (stats.isObject()) {
+        const QJsonObject root = stats.object();
+        const qint64 total = root.value(QStringLiteral("installs_total")).toInteger();
+        const qint64 lastMonth = root.value(QStringLiteral("installs_last_month")).toInteger();
+        if (total > 0) map[QStringLiteral("installsTotal")] = total;
+        if (lastMonth > 0) map[QStringLiteral("installsLastMonth")] = lastMonth;
+    }
+
+    const QJsonDocument verification = QJsonDocument::fromJson(
+        httpGet(QUrl(QStringLiteral("https://flathub.org/api/v2/verification/") + packageId + QStringLiteral("/status")), kSearchTimeoutMs));
+    if (verification.isObject() && verification.object().contains(QStringLiteral("verified"))) {
+        map[QStringLiteral("verified")] = verification.object().value(QStringLiteral("verified")).toBool();
+    }
+
     return map;
 }
 

--- a/src/marketplace/plugins/flatpakplugin.hpp
+++ b/src/marketplace/plugins/flatpakplugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "packageplugin.hpp"
+#include <QJsonObject>
 #include <QSet>
 #include <QSettings>
 
@@ -31,6 +32,10 @@ public:
     QList<QVariantMap> getInstallSources(const QString& packageId) override;
 
     QVariantList getCollection(const QString& collection, int limit);
+
+    static QVariantList permissionEntries(const QJsonObject& permissions);
+    static QVariantList parseLocalPermissions(const QString& output);
+    static QString formatBytes(qint64 bytes);
 
     static QString scopeArgument(const QString& scope);
     static QVariantList parseCollectionHits(const QByteArray& payload, QSet<QString>& seen);


### PR DESCRIPTION
## Problem

Four values on the Flatpak detail page are hardcoded and shown for every application:

```qml
text: "235.5 MB"          // Download Size
text: qsTr("Verified Safe")  // Security Status
text: qsTr("Everyone")       // Content Rating
text: "★★★★★"  /  "4.9 (1.2k ratings)"
```

So VLC, Steam and a five-day-old game all claim the same download size, the same "verified" badge (including the ✓ next to the app name) and the same 4.9-star rating — Flathub has no rating API at all, so that number cannot ever be real.

At the same time the page says nothing about what the sandbox actually allows, which for Flatpak is the one piece of information a store should show before an install.

## Change

- **Real numbers.** `FlatpakPlugin::getDetails()` additionally queries the Flathub `summary`, `stats` and `verification` endpoints: download size, installed size, install counts, verification status and the runtime name. The tiles show download size, publisher (Verified / Community), installed size and how many content-rating categories are flagged (from `content_rating_details`), each falling back to `-` when the API has no data.
- The invented star rating is replaced by "6.0M installs, 129k in the last month" — the numbers Flathub publishes — and the "Official ✓" badge only appears when the app really is verified.
- **Permissions card.** Sandbox permissions are translated into plain language ("Network access", "Legacy X11 windowing system", "All system files", "Folder: Downloads" …), with the ones that break isolation — X11, session/system bus, all devices, host filesystem, home — marked in the error colour. Data comes from the Flathub summary, and for installed apps without API data from `flatpak info --show-permissions`.

## Testing

`astra info org.videolan.VLC --source Flatpak --json` on this machine:

```
downloadSize: 50 MB | installedSize: 133 MB | verified: False | flags: 0
  public          Network access
  volume_up       Audio
  desktop_windows Legacy X11 windowing system   (sensitive)
  devices_other   All devices                   (sensitive)
  folder          Folder: config/kdeglobals
  folder_open     All system files              (sensitive)
  folder          Folder: run/gvfs
```

The GUI shows exactly those tiles and the permission list (screenshot taken from the running app); the local `flatpak info --show-permissions` fallback was verified against an installed app whose summary endpoint returns no metadata. Pacman/AUR/AppImage pages are unchanged, `ctest` passes.