### PR TITLE
feat(operations): let a running install or update be cancelled

### DIFF
--- a/qml/qs/modules/astra/pages/AppDetailPage.qml
+++ b/qml/qs/modules/astra/pages/AppDetailPage.qml
@@ -245,7 +245,7 @@ PageBase {
                 // Flatpak Scope SplitButton (Top)
                 SplitButton {
                     id: scopeSplitBtn
-                    visible: !root.isInstalled && !PackageManager.isBusy && root.appData && root.appData.backend === "Flatpak"
+                    visible: !root.isInstalled && !PackageManager.isOperationRunning && root.appData && root.appData.backend === "Flatpak"
                     Layout.alignment: Qt.AlignRight
                     type: SplitButton.Tonal
                     fallbackIcon: "person"
@@ -275,7 +275,7 @@ PageBase {
                 // Install Button (Directly Below SplitButton)
                 IconTextButton {
                     id: installBtn
-                    visible: !root.isInstalled && !PackageManager.isBusy
+                    visible: !root.isInstalled && !PackageManager.isOperationRunning
                     Layout.alignment: Qt.AlignRight
                     icon: "download"
                     text: qsTr("Install")
@@ -290,7 +290,7 @@ PageBase {
                 RowLayout {
                     Layout.alignment: Qt.AlignRight
                     spacing: Tokens.padding.small
-                    visible: PackageManager.isBusy
+                    visible: PackageManager.isOperationRunning
 
                     CircularIndicator {
                         running: true
@@ -312,7 +312,7 @@ PageBase {
                 RowLayout {
                     Layout.alignment: Qt.AlignRight
                     spacing: Tokens.padding.small
-                    visible: root.isInstalled && !PackageManager.isBusy
+                    visible: root.isInstalled && !PackageManager.isOperationRunning
 
                     IconButton {
                         type: ButtonBase.Text

--- a/qml/qs/modules/astra/pages/LogsPage.qml
+++ b/qml/qs/modules/astra/pages/LogsPage.qml
@@ -25,7 +25,7 @@ PageBase {
             Layout.fillWidth: true
             implicitHeight: bannerRow.implicitHeight + Tokens.padding.medium * 2
             radius: Tokens.rounding.large
-            color: PackageManager.isBusy ? Colours.palette.m3primaryContainer : Colours.palette.m3surfaceContainer
+            color: PackageManager.isOperationRunning ? Colours.palette.m3primaryContainer : Colours.palette.m3surfaceContainer
 
             RowLayout {
                 id: bannerRow
@@ -34,7 +34,7 @@ PageBase {
                 spacing: Tokens.padding.medium
 
                 MaterialIcon {
-                    visible: !PackageManager.isBusy
+                    visible: !PackageManager.isOperationRunning
                     text: "check_circle"
                     fontStyle: Tokens.font.icon.large
                     color: Colours.palette.m3primary
@@ -46,30 +46,39 @@ PageBase {
                     spacing: 2
 
                     StyledText {
-                        text: PackageManager.isBusy
+                        text: PackageManager.isOperationRunning
                             ? (PackageManager.statusMessage || qsTr("Performing package operation..."))
                             : qsTr("System idle / Last operation completed")
                         font: Tokens.font.title.medium
-                        color: PackageManager.isBusy ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                        color: PackageManager.isOperationRunning ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
                         elide: Text.ElideRight
                         Layout.fillWidth: true
                     }
 
                     StyledText {
-                        text: PackageManager.isBusy
+                        text: PackageManager.isOperationRunning
                             ? qsTr("Progress: %1%").arg(PackageManager.currentProgress)
                             : qsTr("Total logged entries: %1").arg(PackageManager.logLines.length)
                         font: Tokens.font.body.small
-                        color: PackageManager.isBusy ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurfaceVariant
+                        color: PackageManager.isOperationRunning ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurfaceVariant
                     }
                 }
 
                 CircularIndicator {
-                    visible: PackageManager.isBusy
-                    running: PackageManager.isBusy
+                    visible: PackageManager.isOperationRunning
+                    running: PackageManager.isOperationRunning
                     implicitSize: 32
                     fgColour: Colours.palette.m3primary
                     Layout.alignment: Qt.AlignVCenter
+                }
+
+                IconTextButton {
+                    visible: PackageManager.isCancellable
+                    icon: "cancel"
+                    text: qsTr("Cancel")
+                    type: ButtonBase.Tonal
+                    Layout.alignment: Qt.AlignVCenter
+                    onClicked: PackageManager.cancelCurrentOperation()
                 }
 
                 IconButton {

--- a/qml/qs/modules/astra/pages/UpdatesPage.qml
+++ b/qml/qs/modules/astra/pages/UpdatesPage.qml
@@ -105,7 +105,7 @@ PageBase {
                 icon: "system_update_alt"
                 text: qsTr("Update All")
                 type: ButtonBase.Filled
-                enabled: !PackageManager.isBusy
+                enabled: !PackageManager.isOperationRunning
                 Layout.alignment: Qt.AlignVCenter
                 onClicked: {
                     PackageManager.updateAllPackages();
@@ -284,7 +284,7 @@ PageBase {
                         icon: "system_update_alt"
                         text: qsTr("Update")
                         type: ButtonBase.Tonal
-                        enabled: !PackageManager.isBusy
+                        enabled: !PackageManager.isOperationRunning
                         Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                         onClicked: {
                             PackageManager.updatePackage(cardRect.modelData.backend, cardRect.modelData.id, cardRect.modelData.scope || "");

--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -209,6 +209,37 @@ QVariantList PackageManager::recentOperations(int limit) const {
     return operations;
 }
 
+astra::CancellationTokenPtr PackageManager::beginCancellableOperation(IPackagePlugin* plugin) {
+    m_cancellation = std::make_shared<astra::CancellationToken>();
+    if (plugin) plugin->setCancellationToken(m_cancellation);
+    emit isCancellableChanged();
+    return m_cancellation;
+}
+
+void PackageManager::endCancellableOperation() {
+    m_lastOperationCancelled = m_cancellation && m_cancellation->isCancelled();
+
+    for (IPackagePlugin* plugin : m_plugins) {
+        plugin->setCancellationToken({});
+    }
+    m_cancellation.reset();
+    emit isCancellableChanged();
+}
+
+void PackageManager::cancelCurrentOperation() {
+    if (!m_cancellation) return;
+
+    appendLog(QStringLiteral("[%1] Cancelling the running operation...").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss"))));
+    m_cancellation->requestCancellation();
+}
+
+void PackageManager::setOperationRunning(bool running) {
+    if (m_operationRunning == running) return;
+
+    m_operationRunning = running;
+    emit isOperationRunningChanged();
+}
+
 void PackageManager::setBusy(bool busy) {
     if (m_isBusy != busy) {
         m_isBusy = busy;
@@ -456,6 +487,8 @@ void PackageManager::clearLogs() {
 }
 
 void PackageManager::installPackage(const QString& backend, const QString& packageId, const QString& scope) {
+    beginCancellableOperation(findPlugin(backend));
+    setOperationRunning(true);
     setBusy(true);
     m_currentProgress = 0;
     emit currentProgressChanged();
@@ -467,13 +500,16 @@ void PackageManager::installPackage(const QString& backend, const QString& packa
     connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher, packageId, backend] {
         bool success = watcher->result();
         watcher->deleteLater();
+        endCancellableOperation();
+        setOperationRunning(false);
         setBusy(false);
         m_currentProgress = success ? 100 : 0;
         emit currentProgressChanged();
         setStatusMessage(QString());
-        appendLog(QStringLiteral("[%1] %2: %3 (%4)").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : QStringLiteral("FAILED"), packageId, backend));
+        appendLog(QStringLiteral("[%1] %2: %3 (%4)").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : (m_lastOperationCancelled ? QStringLiteral("CANCELLED") : QStringLiteral("FAILED")), packageId, backend));
         recordOperation(QStringLiteral("install"), packageId, backend, success);
-        emit operationFinished(success, success ? QStringLiteral("Successfully installed ") + packageId : QStringLiteral("Failed to install ") + packageId);
+        emit operationFinished(success, success ? tr("Successfully installed %1").arg(packageId)
+                                               : (m_lastOperationCancelled ? tr("Cancelled the installation of %1").arg(packageId) : tr("Failed to install %1").arg(packageId)));
     });
 
     QVariantMap opts;
@@ -495,6 +531,8 @@ void PackageManager::installPackage(const QString& backend, const QString& packa
 }
 
 void PackageManager::updatePackage(const QString& backend, const QString& packageId, const QString& scope) {
+    beginCancellableOperation(findPlugin(backend));
+    setOperationRunning(true);
     setBusy(true);
     m_currentProgress = 0;
     emit currentProgressChanged();
@@ -509,13 +547,16 @@ void PackageManager::updatePackage(const QString& backend, const QString& packag
     connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher, packageId, backend] {
         const bool success = watcher->result();
         watcher->deleteLater();
+        endCancellableOperation();
+        setOperationRunning(false);
         setBusy(false);
         m_currentProgress = success ? 100 : 0;
         emit currentProgressChanged();
         setStatusMessage(QString());
-        appendLog(QStringLiteral("[%1] %2: %3 (%4)").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : QStringLiteral("FAILED"), packageId, backend));
+        appendLog(QStringLiteral("[%1] %2: %3 (%4)").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : (m_lastOperationCancelled ? QStringLiteral("CANCELLED") : QStringLiteral("FAILED")), packageId, backend));
         recordOperation(QStringLiteral("update"), packageId, backend, success);
-        emit operationFinished(success, success ? QStringLiteral("Successfully updated ") + packageId : QStringLiteral("Failed to update ") + packageId);
+        emit operationFinished(success, success ? tr("Successfully updated %1").arg(packageId)
+                                               : (m_lastOperationCancelled ? tr("Cancelled the update of %1").arg(packageId) : tr("Failed to update %1").arg(packageId)));
     });
 
     QVariantMap opts;
@@ -537,6 +578,8 @@ void PackageManager::updatePackage(const QString& backend, const QString& packag
 }
 
 void PackageManager::uninstallPackage(const QString& backend, const QString& packageId, const QString& scope) {
+    beginCancellableOperation(findPlugin(backend));
+    setOperationRunning(true);
     setBusy(true);
     m_currentProgress = 0;
     emit currentProgressChanged();
@@ -548,13 +591,16 @@ void PackageManager::uninstallPackage(const QString& backend, const QString& pac
     connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher, packageId, backend] {
         bool success = watcher->result();
         watcher->deleteLater();
+        endCancellableOperation();
+        setOperationRunning(false);
         setBusy(false);
         m_currentProgress = success ? 100 : 0;
         emit currentProgressChanged();
         setStatusMessage(QString());
-        appendLog(QStringLiteral("[%1] %2: %3 (%4)").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : QStringLiteral("FAILED"), packageId, backend));
+        appendLog(QStringLiteral("[%1] %2: %3 (%4)").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : (m_lastOperationCancelled ? QStringLiteral("CANCELLED") : QStringLiteral("FAILED")), packageId, backend));
         recordOperation(QStringLiteral("remove"), packageId, backend, success);
-        emit operationFinished(success, success ? QStringLiteral("Successfully uninstalled ") + packageId : QStringLiteral("Failed to uninstall ") + packageId);
+        emit operationFinished(success, success ? tr("Successfully uninstalled %1").arg(packageId)
+                                               : (m_lastOperationCancelled ? tr("Cancelled the removal of %1").arg(packageId) : tr("Failed to uninstall %1").arg(packageId)));
     });
 
     QVariantMap opts;
@@ -690,38 +736,48 @@ void PackageManager::updateAllPackages() {
     connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher] {
         bool success = watcher->result();
         watcher->deleteLater();
+        endCancellableOperation();
+        setOperationRunning(false);
         setBusy(false);
         setStatusMessage(QString());
         appendLog(QStringLiteral("[%1] %2: System update completed").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), success ? QStringLiteral("SUCCESS") : QStringLiteral("FAILED")));
         recordOperation(QStringLiteral("system"), QString(), QString(), success);
-        emit operationFinished(success, success ? QStringLiteral("All packages updated successfully") : QStringLiteral("Some updates could not be applied"));
+        emit operationFinished(success, success ? tr("All packages updated successfully")
+                                               : (m_lastOperationCancelled ? tr("Cancelled the update") : tr("Some updates could not be applied")));
         checkForUpdatesAsync();
     });
 
-    QFuture<bool> future = QtConcurrent::run([this] {
-        return runSystemUpdate([this](const QString& line) { appendLog(line); });
+    const astra::CancellationTokenPtr token = beginCancellableOperation(nullptr);
+    setOperationRunning(true);
+
+    QFuture<bool> future = QtConcurrent::run([this, token] {
+        return runSystemUpdate([this](const QString& line) { appendLog(line); }, token);
     });
     watcher->setFuture(future);
 }
 
-bool PackageManager::runSystemUpdate(const std::function<void(const QString&)>& logCallback) {
+bool PackageManager::runSystemUpdate(const std::function<void(const QString&)>& logCallback, const astra::CancellationTokenPtr& cancellation) {
     const auto stamped = [&logCallback](const QString& message) {
         logCallback(QStringLiteral("[%1] %2").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), message));
     };
 
     bool success = true;
 
+    const auto cancelled = [&cancellation] { return cancellation && cancellation->isCancelled(); };
+
     if (enableFlatpak() && !QStandardPaths::findExecutable(QStringLiteral("flatpak")).isEmpty()) {
         stamped(QStringLiteral("Running Flatpak update (flatpak update -y)..."));
-        success = astra::runProcessStreaming(QStringLiteral("flatpak"), {QStringLiteral("update"), QStringLiteral("-y")}, logCallback).succeeded() && success;
+        success = astra::runProcessStreaming(QStringLiteral("flatpak"), {QStringLiteral("update"), QStringLiteral("-y")}, logCallback, 0, {}, cancellation).succeeded() && success;
     }
+
+    if (cancelled()) return false;
 
     if (useCaelestiaUpdate() && !QStandardPaths::findExecutable(QStringLiteral("caelestia")).isEmpty()) {
         stamped(QStringLiteral("Running Caelestia update (caelestia update --noconfirm)..."));
-        success = astra::runProcessStreaming(QStringLiteral("caelestia"), {QStringLiteral("update"), QStringLiteral("--noconfirm")}, logCallback).succeeded() && success;
+        success = astra::runProcessStreaming(QStringLiteral("caelestia"), {QStringLiteral("update"), QStringLiteral("--noconfirm")}, logCallback, 0, {}, cancellation).succeeded() && success;
     } else if (enablePacman() && !QStandardPaths::findExecutable(QStringLiteral("pacman")).isEmpty()) {
         stamped(QStringLiteral("Running Pacman update (pkexec pacman -Syu --noconfirm)..."));
-        success = astra::runProcessStreaming(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm")}, logCallback).succeeded() && success;
+        success = astra::runProcessStreaming(QStringLiteral("pkexec"), {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm")}, logCallback, 0, {}, cancellation).succeeded() && success;
     }
 
     return success;

--- a/src/marketplace/packagemanager.hpp
+++ b/src/marketplace/packagemanager.hpp
@@ -41,6 +41,8 @@ class PackageManager : public QObject {
     Q_PROPERTY(int currentProgress READ currentProgress NOTIFY currentProgressChanged)
     Q_PROPERTY(QVariantList registeredPlugins READ getRegisteredPluginsInfo NOTIFY pluginsChanged)
     Q_PROPERTY(QStringList missingBackendTools READ missingBackendTools NOTIFY missingBackendToolsChanged)
+    Q_PROPERTY(bool isCancellable READ isCancellable NOTIFY isCancellableChanged)
+    Q_PROPERTY(bool isOperationRunning READ isOperationRunning NOTIFY isOperationRunningChanged)
 
 public:
     explicit PackageManager(QObject* parent = nullptr);
@@ -49,6 +51,8 @@ public:
     static PackageManager* create(QQmlEngine*, QJSEngine*);
 
     bool isBusy() const { return m_isBusy; }
+    bool isCancellable() const { return m_cancellation != nullptr; }
+    bool isOperationRunning() const { return m_operationRunning; }
     bool enableFlatpak() const;
     bool enablePacman() const;
     bool enableAur() const;
@@ -73,7 +77,7 @@ public:
     void setUseCaelestiaUpdate(bool enable);
     void setAurHelper(const QString& helper);
 
-    bool runSystemUpdate(const std::function<void(const QString&)>& logCallback);
+    bool runSystemUpdate(const std::function<void(const QString&)>& logCallback, const astra::CancellationTokenPtr& cancellation = {});
 
     void registerPlugin(IPackagePlugin* plugin);
     QList<IPackagePlugin*> plugins() const { return m_plugins; }
@@ -99,11 +103,14 @@ public:
     Q_INVOKABLE void updateAllPackages();
     Q_INVOKABLE QVariantList recentOperations(int limit = 8) const;
     void recordOperation(const QString& action, const QString& packageId, const QString& backend, bool success);
+    Q_INVOKABLE void cancelCurrentOperation();
     Q_INVOKABLE void appendLog(const QString& line);
     Q_INVOKABLE void clearLogs();
 
 signals:
     void isBusyChanged();
+    void isCancellableChanged();
+    void isOperationRunningChanged();
     void enableFlatpakChanged();
     void enablePacmanChanged();
     void enableAurChanged();
@@ -126,10 +133,14 @@ signals:
 
 private:
     void setBusy(bool busy);
+    void setOperationRunning(bool running);
+    astra::CancellationTokenPtr beginCancellableOperation(IPackagePlugin* plugin);
+    void endCancellableOperation();
     void setStatusMessage(const QString& message);
     void initPlugins();
 
     bool m_isBusy{false};
+    bool m_operationRunning{false};
     QString m_statusMessage;
     QStringList m_logLines;
     int m_currentProgress{0};
@@ -141,6 +152,8 @@ private:
     QList<IPackagePlugin*> m_plugins;
 
     QThreadPool m_pluginPool;
+    astra::CancellationTokenPtr m_cancellation;
+    bool m_lastOperationCancelled{false};
     QHash<QString, QVariantList> m_collections;
     QSet<QString> m_pendingCollections;
 

--- a/src/marketplace/pluginprocess.cpp
+++ b/src/marketplace/pluginprocess.cpp
@@ -22,7 +22,7 @@ QProcessEnvironment parsableEnvironment() {
     return environment;
 }
 
-ProcessResult run(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs, bool mergeChannels, const ProcessEnvironmentOverrides& environmentOverrides) {
+ProcessResult run(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs, bool mergeChannels, const ProcessEnvironmentOverrides& environmentOverrides, const CancellationTokenPtr& cancellation) {
     ProcessResult result;
 
     QProcessEnvironment environment = parsableEnvironment();
@@ -81,6 +81,16 @@ ProcessResult run(const QString& program, const QStringList& arguments, const Pr
         process.waitForReadyRead(200);
         drain(false);
 
+        if (cancellation && cancellation->isCancelled()) {
+            result.cancelled = true;
+            process.terminate();
+            if (!process.waitForFinished(3000)) {
+                process.kill();
+                process.waitForFinished(1000);
+            }
+            break;
+        }
+
         if (timeoutMs > 0 && elapsed.hasExpired(timeoutMs)) {
             result.timedOut = true;
             process.kill();
@@ -92,18 +102,18 @@ ProcessResult run(const QString& program, const QStringList& arguments, const Pr
     process.waitForFinished(1000);
     drain(true);
 
-    if (!result.timedOut) result.exitCode = process.exitCode();
+    if (!result.timedOut && !result.cancelled) result.exitCode = process.exitCode();
     return result;
 }
 
 }
 
 ProcessResult runProcess(const QString& program, const QStringList& arguments, int timeoutMs) {
-    return run(program, arguments, nullptr, timeoutMs, false, {});
+    return run(program, arguments, nullptr, timeoutMs, false, {}, {});
 }
 
-ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs, const ProcessEnvironmentOverrides& environmentOverrides) {
-    return run(program, arguments, lineCallback, timeoutMs, true, environmentOverrides);
+ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs, const ProcessEnvironmentOverrides& environmentOverrides, const CancellationTokenPtr& cancellation) {
+    return run(program, arguments, lineCallback, timeoutMs, true, environmentOverrides, cancellation);
 }
 
 }

--- a/src/marketplace/pluginprocess.hpp
+++ b/src/marketplace/pluginprocess.hpp
@@ -3,18 +3,32 @@
 #include <QMap>
 #include <QString>
 #include <QStringList>
+#include <atomic>
 #include <functional>
+#include <memory>
 
 namespace astra {
+
+class CancellationToken {
+public:
+    void requestCancellation() { m_cancelled.store(true); }
+    bool isCancelled() const { return m_cancelled.load(); }
+
+private:
+    std::atomic_bool m_cancelled{false};
+};
+
+using CancellationTokenPtr = std::shared_ptr<CancellationToken>;
 
 struct ProcessResult {
     int exitCode{-1};
     bool timedOut{false};
     bool started{false};
+    bool cancelled{false};
     QString output;
     QString error;
 
-    bool succeeded() const { return started && !timedOut && exitCode == 0; }
+    bool succeeded() const { return started && !timedOut && !cancelled && exitCode == 0; }
 };
 
 using ProcessLineCallback = std::function<void(const QString& line)>;
@@ -22,6 +36,6 @@ using ProcessLineCallback = std::function<void(const QString& line)>;
 using ProcessEnvironmentOverrides = QMap<QString, QString>;
 
 ProcessResult runProcess(const QString& program, const QStringList& arguments, int timeoutMs = 15000);
-ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs = 0, const ProcessEnvironmentOverrides& environmentOverrides = {});
+ProcessResult runProcessStreaming(const QString& program, const QStringList& arguments, const ProcessLineCallback& lineCallback, int timeoutMs = 0, const ProcessEnvironmentOverrides& environmentOverrides = {}, const CancellationTokenPtr& cancellation = {});
 
 }

--- a/src/marketplace/plugins/aurplugin.cpp
+++ b/src/marketplace/plugins/aurplugin.cpp
@@ -323,7 +323,7 @@ bool AurPlugin::runHelperOperation(const QStringList& operation, ProgressCallbac
 
     const astra::ProcessResult result = astra::runProcessStreaming(helper, invocation.arguments, [&progressCb](const QString& line) {
         if (progressCb) progressCb(50, line);
-    }, 0, invocation.environment);
+    }, 0, invocation.environment, m_cancellation);
 
     if (progressCb && !result.succeeded() && result.started) {
         progressCb(0, QStringLiteral("%1 exited with status %2").arg(helper, QString::number(result.exitCode)));

--- a/src/marketplace/plugins/flatpakplugin.cpp
+++ b/src/marketplace/plugins/flatpakplugin.cpp
@@ -421,7 +421,7 @@ bool FlatpakPlugin::install(const QString& packageId, const QVariantMap& options
         if (message.isEmpty()) return;
         const int percent = percentFromLine(line);
         progressCb(percent < 0 ? 50 : percent, message);
-    });
+    }, 0, {}, m_cancellation);
     return result.succeeded();
 }
 
@@ -439,7 +439,7 @@ bool FlatpakPlugin::uninstall(const QString& packageId, const QVariantMap& optio
         if (message.isEmpty()) return;
         const int percent = percentFromLine(line);
         progressCb(percent < 0 ? 50 : percent, message);
-    });
+    }, 0, {}, m_cancellation);
     return result.succeeded();
 }
 
@@ -458,7 +458,7 @@ bool FlatpakPlugin::update(const QString& packageId, const QVariantMap& options,
         if (message.isEmpty()) return;
         const int percent = percentFromLine(line);
         progressCb(percent < 0 ? 50 : percent, message);
-    });
+    }, 0, {}, m_cancellation);
     return result.succeeded();
 }
 

--- a/src/marketplace/plugins/packageplugin.hpp
+++ b/src/marketplace/plugins/packageplugin.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "pluginprocess.hpp"
+
 #include <QString>
 #include <QVariantList>
 #include <QVariantMap>
@@ -41,6 +43,11 @@ public:
         Q_UNUSED(packageId);
         return {};
     }
+
+    void setCancellationToken(const astra::CancellationTokenPtr& cancellation) { m_cancellation = cancellation; }
+
+protected:
+    astra::CancellationTokenPtr m_cancellation;
 
 signals:
     void availabilityChanged();

--- a/src/marketplace/plugins/pacmanplugin.cpp
+++ b/src/marketplace/plugins/pacmanplugin.cpp
@@ -244,7 +244,8 @@ bool PacmanPlugin::install(const QString& packageId, const QVariantMap& options,
         {QStringLiteral("pacman"), QStringLiteral("-S"), QStringLiteral("--noconfirm"), packageId},
         [&progressCb](const QString& line) {
             if (progressCb) progressCb(50, line);
-        });
+        },
+        0, {}, m_cancellation);
 
     if (progressCb && !result.succeeded() && !result.started) {
         progressCb(0, QStringLiteral("Could not start pkexec"));
@@ -261,7 +262,8 @@ bool PacmanPlugin::uninstall(const QString& packageId, const QVariantMap& option
         {QStringLiteral("pacman"), QStringLiteral("-Rns"), QStringLiteral("--noconfirm"), packageId},
         [&progressCb](const QString& line) {
             if (progressCb) progressCb(50, line);
-        });
+        },
+        0, {}, m_cancellation);
 
     if (progressCb && !result.succeeded() && !result.started) {
         progressCb(0, QStringLiteral("Could not start pkexec"));
@@ -278,7 +280,8 @@ bool PacmanPlugin::update(const QString& packageId, const QVariantMap& options, 
         {QStringLiteral("pacman"), QStringLiteral("-Syu"), QStringLiteral("--noconfirm"), packageId},
         [&progressCb](const QString& line) {
             if (progressCb) progressCb(50, line);
-        });
+        },
+        0, {}, m_cancellation);
 
     if (progressCb && !result.started) {
         progressCb(0, QStringLiteral("Could not start pkexec"));

--- a/src/marketplace/plugins/scriptableplugin.cpp
+++ b/src/marketplace/plugins/scriptableplugin.cpp
@@ -132,6 +132,16 @@ ScriptablePlugin::ScriptResult ScriptablePlugin::runCommand(const QString& cmdTe
         proc.waitForReadyRead(200);
         drain(false);
 
+        if (m_cancellation && m_cancellation->isCancelled()) {
+            proc.terminate();
+            if (!proc.waitForFinished(3000)) {
+                proc.kill();
+                proc.waitForFinished(1000);
+            }
+            result.timedOut = true;
+            break;
+        }
+
         if (timeoutMs > 0 && elapsed.hasExpired(timeoutMs)) {
             result.timedOut = true;
             proc.kill();


### PR DESCRIPTION
## Problems

**1. Operations cannot be stopped.** `installPackage()` / `updatePackage()` / `uninstallPackage()` / `updateAllPackages()` start a process and wait for it. There is no cancel path anywhere, so a download stuck at 3 KB/s or a wrong package can only be stopped by killing the app — which leaves pacman or flatpak running unsupervised.

**2. `isBusy` means two different things.** Searches, installed-list refreshes and update checks set the same flag as installs and removals. A background update check finishing during an install flips the flag to false, so the logs page claims "System idle / Last operation completed" while the install is still writing to the log, and the install buttons become clickable again mid-operation.

## Change

- `astra::CancellationToken` (a shared `std::atomic_bool`) is passed into `runProcessStreaming()`; the read loop checks it, calls `terminate()`, waits three seconds and only then `kill()`s, so a package manager gets the chance to stop cleanly at a safe point.
- Plugins receive the token through `IPackagePlugin::setCancellationToken()` and pass it to every long-running command (pacman, AUR helper, flatpak, scriptable plugins); the system update path passes it as well and stops between the flatpak and the pacman/Caelestia step.
- `PackageManager` creates a token per operation and exposes `isCancellable` and `cancelCurrentOperation()`. A cancelled operation is reported as cancelled — "CANCELLED" in the log, "Cancelled the installation of …" as the finished message — instead of a plain failure.
- The logs page shows a **Cancel** button while an operation is running.
- New `isOperationRunning` property, set only by real operations. The logs banner, the install/uninstall buttons and the per-package update buttons use it; loading indicators keep using `isBusy`.

## Testing

Driven through `PackageManager` directly against a plugin whose install script sleeps 20 s:

```
cancellable before start: false
cancellable while running: true
requesting cancellation at 2061 ms
finished after 5206 ms, success=false, message=Cancelled the installation of demo-app
cancellable after finish: false
marker written: no          <- the script never reached its completion step
```

The 3 s difference is the grace period: the script blocks in `sleep`, so it is killed after the timeout — a package manager that handles SIGTERM exits earlier.

In the GUI the logs banner shows "Installing demo-app / Progress: 50%" with a spinner and the Cancel button while the operation runs (screenshot from the running app); before the `isOperationRunning` fix the same banner said "System idle" because a background update check had cleared `isBusy`. `ctest` passes.