### PR TITLE
feat(ui): add keyboard shortcuts for search, refresh and navigation

### DIFF
--- a/qml/qs/modules/astra/Astra.qml
+++ b/qml/qs/modules/astra/Astra.qml
@@ -6,6 +6,7 @@ import AstraMarket.Config
 import qs.components
 import qs.components.controls
 import qs.services
+import QtQuick.Controls
 import qs.modules.astra
 
 Item {
@@ -15,8 +16,37 @@ Item {
         id: nState
 
         onClose: root.close()
+        onSubPageOpened: root.openSubPages++
+        onSubPageClosed: root.openSubPages = Math.max(0, root.openSubPages - 1)
+        onCurrentPageIdxChanged: root.openSubPages = 0
+    }
+
+    Shortcut {
+        sequences: [StandardKey.Find, "Ctrl+F"]
+        onActivated: nState.focusSearchRequested()
+    }
+
+    Shortcut {
+        sequences: [StandardKey.Refresh, "Ctrl+R"]
+        onActivated: nState.refreshRequested()
+    }
+
+    Shortcut {
+        sequence: "Escape"
+        enabled: root.openSubPages > 0
+        onActivated: nState.closeSubPage()
+    }
+
+    Shortcut {
+        sequences: ["Ctrl+1", "Ctrl+2", "Ctrl+3", "Ctrl+4", "Ctrl+5", "Ctrl+6"]
+        onActivated: seq => {
+            const index = parseInt(seq.toString().slice(-1), 10) - 1;
+            if (index >= 0 && index < PageRegistry.pages.length)
+                nState.currentPageIdx = index;
+        }
     }
     property color blobColour: Colours.tPalette.m3surfaceContainerLow
+    property int openSubPages: 0
 
     signal close
 

--- a/qml/qs/modules/astra/AstraState.qml
+++ b/qml/qs/modules/astra/AstraState.qml
@@ -22,6 +22,8 @@ QtObject {
     signal close
     signal subPageOpened(idx: int)
     signal subPageClosed
+    signal focusSearchRequested
+    signal refreshRequested
 
     function openSubPage(idx: int): void {
         subPageIdxStack.push(idx);

--- a/qml/qs/modules/astra/pages/ExplorePage.qml
+++ b/qml/qs/modules/astra/pages/ExplorePage.qml
@@ -126,6 +126,22 @@ PageBase {
         spacing: Tokens.spacing.extraSmall / 2
 
         Connections {
+            target: root.nState
+
+            function onFocusSearchRequested(): void {
+                searchBar.forceActiveFocus();
+                searchBar.selectAll();
+            }
+
+            function onRefreshRequested(): void {
+                if (root.hasActiveQuery)
+                    root.refreshSearch();
+                else
+                    root.loadHomeFeed();
+            }
+        }
+
+        Connections {
             target: PackageManager
             function onSearchCompleted(results): void {
                 root.packagesList = results ? results : [];
@@ -145,6 +161,8 @@ PageBase {
             spacing: Tokens.padding.medium
 
             SearchBar {
+                id: searchBar
+
                 Layout.fillWidth: true
                 placeholderText: qsTr("Search Flatpak, Pacman, AUR...")
                 onTextChanged: {

--- a/qml/qs/modules/astra/pages/InstalledPage.qml
+++ b/qml/qs/modules/astra/pages/InstalledPage.qml
@@ -45,6 +45,13 @@ PageBase {
 
     data: [
         Connections {
+            target: root.nState
+
+            function onRefreshRequested(): void {
+                root.refreshList();
+            }
+        },
+        Connections {
             target: PackageManager
             function onInstalledCompleted(results): void {
                 root.installedList = results ? results : [];

--- a/qml/qs/modules/astra/pages/UpdatesPage.qml
+++ b/qml/qs/modules/astra/pages/UpdatesPage.qml
@@ -51,6 +51,13 @@ PageBase {
 
     data: [
         Connections {
+            target: root.nState
+
+            function onRefreshRequested(): void {
+                root.checkUpdates();
+            }
+        },
+        Connections {
             target: PackageManager
             function onUpdatesCompleted(updates): void {
                 root.updatesList = updates ? updates : [];


### PR DESCRIPTION
## Problem

The window is mouse-only. There is no way to focus the search field, refresh a list, leave a detail page or switch sections without clicking, which also makes the app awkward on a tiling setup where the pointer is not where the hands are.

## Change

Shortcuts on the window:

| Key | Action |
| --- | --- |
| `Ctrl+F`, platform find key | Focus and select the search field |
| `Ctrl+R`, `F5` | Refresh the current page |
| `Escape` | Leave the current sub page (detail page, logs) |
| `Ctrl+1` … `Ctrl+6` | Switch to that section in the navigation pane |

`Escape` is only active while a sub page is open, so it never closes the window unexpectedly. The refresh and focus requests go through two new signals on `AstraState`, so each page decides what it means: Explore refreshes the search or reloads the Flathub feed, Installed reloads the package list, Updates checks for updates again.

## Testing

Qt registers the shortcuts on the window (from the app's own debug output):

```
QShortcutMap::addShortcut(QQuickShortcut, QKeySequence("Ctrl+F"), Qt::WindowShortcut)
… QKeySequence("Find"), QKeySequence("Ctrl+R"), QKeySequence("F5"), QKeySequence("Esc"),
  QKeySequence("Ctrl+1") … QKeySequence("Ctrl+6")
```

and the signal chain behind them was driven directly in the running app:

```
TEST emitting focusSearchRequested
TEST searchBar.activeFocus = true
TEST emitting refreshRequested
TEST refresh received on ExplorePage
```

No ambiguous-shortcut warnings, `ctest` passes, and the rest of the UI is unchanged.