### PR TITLE
feat(appimage): check for and apply AppImage updates

### DIFF
--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -101,6 +101,12 @@ QStringList PackageManager::missingBackendTools() const {
         missing.append(tr("No AUR helper found, install paru or yay to manage AUR packages"));
     }
 
+    if (m_appimagePlugin && m_appimagePlugin->isEnabled() &&
+        QStandardPaths::findExecutable(QStringLiteral("appimageupdatetool")).isEmpty() &&
+        !m_appimagePlugin->getInstalled().isEmpty()) {
+        missing.append(tr("appimageupdatetool is missing, AppImages are not checked for updates"));
+    }
+
     return missing;
 }
 

--- a/src/marketplace/plugins/appimageplugin.cpp
+++ b/src/marketplace/plugins/appimageplugin.cpp
@@ -1,9 +1,20 @@
 #include "appimageplugin.hpp"
 #include "appimageinstaller.hpp"
+#include "pluginprocess.hpp"
 
+#include <QFile>
 #include <QFileInfo>
 #include <QProcess>
+#include <QStandardPaths>
 #include <QUrl>
+
+namespace {
+constexpr int kCheckTimeoutMs = 30000;
+
+QString updateTool() {
+    return QStandardPaths::findExecutable(QStringLiteral("appimageupdatetool"));
+}
+}
 
 AppImagePlugin::AppImagePlugin(QObject* parent) : IPackagePlugin(parent) {
     m_enabled = m_settings.value(QStringLiteral("AppImage/enabled"), true).toBool();
@@ -54,7 +65,54 @@ QVariantList AppImagePlugin::getInstalled() {
 }
 
 QVariantList AppImagePlugin::getUpdates() {
-    return {};
+    QVariantList updates;
+    if (!m_enabled) return updates;
+
+    const QString tool = updateTool();
+    if (tool.isEmpty()) return updates;
+
+    const QVariantList installed = getInstalled();
+    for (const QVariant& value : installed) {
+        const QVariantMap entry = value.toMap();
+        const QString path = entry.value(QStringLiteral("path")).toString();
+        if (path.isEmpty() || !QFile::exists(path)) continue;
+
+        const astra::ProcessResult check = astra::runProcess(tool, {QStringLiteral("--check-for-update"), path}, kCheckTimeoutMs);
+        if (!check.started || check.exitCode != 1) continue;
+
+        QVariantMap item = entry;
+        item[QStringLiteral("version")] = tr("new version available");
+        updates.append(item);
+    }
+    return updates;
+}
+
+bool AppImagePlugin::update(const QString& packageId, const QVariantMap& options, ProgressCallback progressCb) {
+    Q_UNUSED(options);
+    if (!m_enabled) return false;
+
+    const QString tool = updateTool();
+    if (tool.isEmpty()) {
+        if (progressCb) progressCb(0, tr("appimageupdatetool is not installed, AppImages cannot be updated"));
+        return false;
+    }
+
+    const QVariantMap entry = AppImageInstaller::findInstalledAppImage(packageId);
+    const QString path = entry.value(QStringLiteral("path")).toString();
+    if (path.isEmpty() || !QFile::exists(path)) {
+        if (progressCb) progressCb(0, tr("No installed AppImage matches %1").arg(packageId));
+        return false;
+    }
+
+    const astra::ProcessResult result = astra::runProcessStreaming(
+        tool,
+        {QStringLiteral("--overwrite"), path},
+        [&progressCb](const QString& line) {
+            if (progressCb) progressCb(50, line);
+        },
+        0, {}, m_cancellation);
+
+    return result.succeeded();
 }
 
 QVariantMap AppImagePlugin::getDetails(const QString& packageId) {

--- a/src/marketplace/plugins/appimageplugin.hpp
+++ b/src/marketplace/plugins/appimageplugin.hpp
@@ -24,6 +24,7 @@ public:
 
     bool install(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool uninstall(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
+    bool update(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
 
 private:


### PR DESCRIPTION
## Problem

```cpp
QVariantList AppImagePlugin::getUpdates() {
    return {};
}
```

An installed AppImage can never be updated from the app. AppImages carry embedded zsync update information for exactly this purpose, and the reference implementation (`appimageupdatetool` from AppImageUpdate) is a single command away.

## Change

- `getUpdates()` asks `appimageupdatetool --check-for-update <file>` for every installed AppImage and reports the ones where it exits with status 1 (update available). AppImages then appear on the updates page like every other package.
- `update()` runs `appimageupdatetool --overwrite <file>`, streams the tool's progress into the operation log and honours the cancellation token from #18.
- When the tool is missing nothing is checked — no errors, no noise — and `missingBackendTools` reports it on the updates page, but only when AppImages are actually installed.

## Testing

Against a stub `appimageupdatetool` on `PATH` (so nothing was downloaded), with two AppImages installed — one through the installer, one standalone in `~/Applications`:

```
$ astra update --json            # without the tool
[]                               # no AppImage entries

$ astra update --json            # with the tool reporting "update available"
[('astra-test-app-2-1-x86_64', 'new version available'),
 ('waywallen-0.1.4-…', 'new version available')]
appimageupdatetool --check-for-update /home/…/.local/bin/astra-test-app-2-1-x86_64.AppImage
appimageupdatetool --check-for-update /home/…/Applications/waywallen-0.1.4-….AppImage

$ astra upgrade astra-test-app-2-1-x86_64 --source AppImage
  Updating /home/…/astra-test-app-2-1-x86_64.AppImage
  0% done
  100% done
Successfully updated astra-test-app-2-1-x86_64
appimageupdatetool --overwrite /home/…/astra-test-app-2-1-x86_64.AppImage

$ astra upgrade astra-test-app-2-1-x86_64 --source AppImage   # without the tool
  appimageupdatetool is not installed, AppImages cannot be updated
Failed to update astra-test-app-2-1-x86_64
```

`ctest` passes, other backends are untouched.