### PR TITLE
chore: point the polkit vendor url at the renamed repository

### DIFF
--- a/assets/polkit/com.astra-foundry.pacman.policy
+++ b/assets/polkit/com.astra-foundry.pacman.policy
@@ -2,7 +2,7 @@
 <!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN" "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 <policyconfig>
   <vendor>Foundry</vendor>
-  <vendor_url>https://github.com/dim-ghub/AstraMarket</vendor_url>
+  <vendor_url>https://github.com/dim-ghub/Foundry</vendor_url>
   <icon_name>astra-foundry</icon_name>
   <action id="com.astra-foundry.pacman.update">
     <description>Run pacman package operations</description>


### PR DESCRIPTION
The repository is now `dim-ghub/Foundry`, so the `vendor_url` in `com.astra-foundry.pacman.policy` — the link shown in the PolicyKit authentication dialog — points at the old name.

It is the only place in the tree that still carries the old repository path; the two remaining `AstraMarket` strings are intentional: the legacy config/data directories that `migrateLegacyPaths()` moves on first start, and the historical `10-astramarket-pacman.rules` filename in the README removal instructions.

`xmllint` passes on the policy file.