### PR TITLE
chore: bump the version fallbacks to 1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(GIT_TAG_VERSION MATCHES "^v?([0-9]+\\.[0-9]+.*)")
     string(REGEX REPLACE "^v" "" ASTRA_VERSION_RAW "${GIT_TAG_VERSION}")
     set(ASTRA_VERSION_STR "${ASTRA_VERSION_RAW}")
 else()
-    set(ASTRA_VERSION_STR "1.1.0")
+    set(ASTRA_VERSION_STR "1.2.0")
 endif()
 
 project(astra-foundry VERSION ${ASTRA_VERSION_STR} LANGUAGES CXX)

--- a/qml/qs/modules/astra/pages/AboutPage.qml
+++ b/qml/qs/modules/astra/pages/AboutPage.qml
@@ -41,7 +41,7 @@ PageBase {
 
                 StyledText {
                     Layout.alignment: Qt.AlignHCenter
-                    text: qsTr("v%1").arg(typeof appVersion !== "undefined" ? appVersion : "1.1.0")
+                    text: qsTr("v%1").arg(typeof appVersion !== "undefined" ? appVersion : "1.2.0")
                     font: Tokens.font.body.medium
                     color: Colours.palette.m3onSurfaceVariant
                 }

--- a/src/cli/clihandler.cpp
+++ b/src/cli/clihandler.cpp
@@ -11,7 +11,7 @@
 #include <unistd.h>
 
 #ifndef ASTRA_VERSION
-#define ASTRA_VERSION "1.1.0"
+#define ASTRA_VERSION "1.2.0"
 #endif
 
 namespace {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@
 #include <QLocalSocket>
 
 #ifndef ASTRA_VERSION
-#define ASTRA_VERSION "1.1.0"
+#define ASTRA_VERSION "1.2.0"
 #endif
 
 static void migrateLegacyPaths() {


### PR DESCRIPTION
The version normally comes from `git describe` at configure time; these four literals are the fallbacks used when that is unavailable (source tarball without tags, missing `ASTRA_VERSION` define, `appVersion` not set in QML). They still said 1.1.0.

Preparation for tagging v1.2.0.