### PR TITLE
chore: add issue forms and a pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check you are on a current build first. More than one report has turned out to be
+        a fix that was already merged but not yet compiled locally.
+
+  - type: input
+    id: version
+    attributes:
+      label: Build
+      description: The package version, or the output of `git log -1 --format=%h` if you built it yourself.
+      placeholder: astra-foundry 1.0.0-1, or 8bb6db3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where
+      description: Which part of Foundry. Pick the closest one.
+      options:
+        - Flatpak source
+        - Pacman source
+        - AUR source
+        - AppImage source
+        - A plugin or custom source
+        - Graphical interface
+        - Command line
+        - Somewhere else
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: What you did
+      description: The steps, in order. Include the detail that seems irrelevant — it is often the one that finds it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: result
+    attributes:
+      label: What happened, and what you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshot, recording or output
+      description: |
+        Drag files straight into this box. For anything that moves, a recording beats a screenshot.
+
+  - type: input
+    id: setup
+    attributes:
+      label: Anything specific about your setup
+      description: Only if it might matter.
+      placeholder: paru as the AUR helper, CachyOS

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest something Foundry should be able to do
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What should it do
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: What are you trying to get done
+      description: |
+        The problem behind the request. This matters more than the proposed solution — there is
+        often a simpler way to the same place, and knowing the goal is what finds it.
+    validations:
+      required: true
+
+  - type: input
+    id: prior_art
+    attributes:
+      label: Somewhere this already exists
+      description: If another tool does this, naming it is the fastest way to show what you mean.
+      placeholder: pacman, paru, apt

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## What this changes
+
+
+
+## Why
+
+
+
+## How it was verified
+
+<!--
+What you actually did, not "works for me". If you could not verify part of it, say which part
+and why — that is useful, not a weakness.
+-->
+
+
+
+<!--
+Before opening:
+
+- Rebased on current main and built it there.
+- Debugging removed: commented-out lines, properties flipped to test something, timers added
+  to reproduce a bug.
+- Tests run: `ctest --test-dir build --output-on-failure`. A parser change should come
+  with a fixture, see CONTRIBUTING.
+- Unrelated changes left out, or explained in one sentence if they had to come along.
+-->


### PR DESCRIPTION
Same forms as [Atlas#70](https://github.com/dim-ghub/Atlas/pull/70), with the area list rewritten for Foundry: the four package sources, plugins, and the two interfaces — a bug in the Pacman source and one in the CLI are rarely the same bug.

Build and area are required fields. Both have cost time by being absent from reports elsewhere: a report made against a stale build, and a report that did not say which part of the UI it concerned.

The pull request checklist points at `CONTRIBUTING.md` for the test command rather than repeating it, and reminds contributors that a parser change wants a fixture.

Labels limited to `bug` and `enhancement`, both of which already exist here. Both YAML files parse.