### PR TITLE
feat(i18n): translate the interface and ship German

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
             qt6-base \
             qt6-declarative \
             qt6-shadertools \
-            qt6-svg
+            qt6-svg \
+            qt6-tools
 
       - name: Mark git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,17 @@ qt_add_resources(astra "qml_resources"
     FILES ${QML_FILES}
 )
 
+find_package(Qt6 QUIET COMPONENTS LinguistTools)
+
+if(Qt6LinguistTools_FOUND)
+    qt_add_translations(astra
+        TS_FILES translations/foundry_de.ts
+        RESOURCE_PREFIX "/i18n"
+    )
+else()
+    message(STATUS "Qt Linguist tools not found, Foundry is built without translations")
+endif()
+
 option(ASTRA_BUILD_TESTS "Build the Foundry unit tests" OFF)
 
 if(ASTRA_BUILD_TESTS)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ Every push and pull request builds on Arch Linux and runs the test suite (`.gith
 - QML follows the structure of the existing pages: tokens from `Foundry.Config` for sizing, spacing
   and typography, colours from `qs.services` (`Colours.palette`), and the shared components in
   `qml/qs/components` instead of raw `Rectangle`/`Text` items.
-- User visible strings go through `qsTr()`.
+- User visible strings go through `qsTr()` in QML and `tr()` in C++, and end up in `translations/`.
+  After adding or changing strings, run `cmake --build build --target update_translations` and translate
+  the new entries in `translations/foundry_de.ts` (or leave them empty, English is the fallback).
 
 ## Backends
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ sudo rm -f /usr/share/polkit-1/rules.d/10-astramarket-pacman.rules
 
 For creating and installing custom package sources or scrapers, see [PLUGINS](PLUGINS.md).
 
+## Translations
+
+The interface is translatable and ships with German. Translation files live in `translations/` and are
+compiled into the binary when the Qt Linguist tools are available (`qt6-tools` on Arch); without them the
+build falls back to English. The language is picked from the system locale at startup.
+
+Refresh the strings after changing the UI:
+
+```bash
+cmake --build build --target update_translations
+```
+
+To add a language, copy `translations/foundry_de.ts` to `translations/foundry_<code>.ts`, add it to the
+`qt_add_translations()` call in `CMakeLists.txt` and translate it with Qt Linguist.
+
 ## Contributing
 
 Build instructions, the test setup and the code style are described in [CONTRIBUTING](CONTRIBUTING.md).

--- a/qml/qs/modules/astra/pages/ExplorePage.qml
+++ b/qml/qs/modules/astra/pages/ExplorePage.qml
@@ -238,7 +238,7 @@ PageBase {
                             }
 
                             StyledText {
-                                text: chip.modelData
+                                text: chip.modelData === "All" ? qsTr("All") : chip.modelData
                                 font: Tokens.font.label.large
                                 color: chip.isSelected ? Colours.palette.m3onSecondaryContainer : Colours.palette.m3onSurface
                             }
@@ -327,14 +327,14 @@ PageBase {
 
                     Repeater {
                         model: [
-                            { name: "Photo & Video", icon: "photo_camera" },
-                            { name: "Music & Audio", icon: "headphones" },
-                            { name: "Productivity", icon: "work" },
-                            { name: "Communication & News", icon: "forum" },
-                            { name: "Education & Science", icon: "school" },
-                            { name: "Games", icon: "sports_esports" },
-                            { name: "Utilities", icon: "build" },
-                            { name: "Development", icon: "code" }
+                            { name: "Photo & Video", label: qsTr("Photo & Video"), icon: "photo_camera" },
+                            { name: "Music & Audio", label: qsTr("Music & Audio"), icon: "headphones" },
+                            { name: "Productivity", label: qsTr("Productivity"), icon: "work" },
+                            { name: "Communication & News", label: qsTr("Communication & News"), icon: "forum" },
+                            { name: "Education & Science", label: qsTr("Education & Science"), icon: "school" },
+                            { name: "Games", label: qsTr("Games"), icon: "sports_esports" },
+                            { name: "Utilities", label: qsTr("Utilities"), icon: "build" },
+                            { name: "Development", label: qsTr("Development"), icon: "code" }
                         ]
 
                         Rectangle {
@@ -417,7 +417,7 @@ PageBase {
                                 }
 
                                 StyledText {
-                                    text: modelData.name
+                                    text: modelData.label ?? modelData.name
                                     font: Tokens.font.label.large
                                     color: pillItem.isSelected ? Colours.palette.m3onPrimary : Colours.palette.m3onPrimaryContainer
                                     Layout.alignment: Qt.AlignVCenter

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include <QIcon>
 #include <QDir>
 #include <QCommandLineParser>
+#include <QLocale>
+#include <QTranslator>
 #include <QStandardPaths>
 #include <QCommandLineOption>
 #include <QProcess>
@@ -52,6 +54,15 @@ static void migrateLegacyPaths() {
     for (const auto& [legacy, current] : locations) {
         if (!QFileInfo::exists(legacy) || QFileInfo::exists(current)) continue;
         QDir().rename(legacy, current);
+    }
+}
+
+static void installTranslations(QCoreApplication& app) {
+    auto* translator = new QTranslator(&app);
+    if (translator->load(QLocale(), QStringLiteral("foundry"), QStringLiteral("_"), QStringLiteral(":/i18n"))) {
+        QCoreApplication::installTranslator(translator);
+    } else {
+        delete translator;
     }
 }
 
@@ -128,6 +139,7 @@ int main(int argc, char* argv[]) {
     app.setDesktopFileName(QStringLiteral("astra"));
     app.setApplicationVersion(QStringLiteral(ASTRA_VERSION));
     app.setQuitOnLastWindowClosed(false);
+    installTranslations(app);
 
     const QString iconPath = QStringLiteral(":/assets/icons/astra-foundry.svg");
     if (QFile::exists(iconPath)) {

--- a/translations/foundry_de.ts
+++ b/translations/foundry_de.ts
@@ -1,0 +1,1166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
+<context>
+    <name>AboutPage</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/pages/AboutPage.qml" line="+13" />
+        <source>About</source>
+        <translation>Über</translation>
+    </message>
+    <message>
+        <location line="+31" />
+        <source>v%1</source>
+        <translation>v%1</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>Next-generation Linux Marketplace with unified multi-backend package support.</source>
+        <translation>Linux-Marktplatz der nächsten Generation mit einheitlicher Unterstützung für mehrere Paketquellen.</translation>
+    </message>
+    <message>
+        <location line="+11" />
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <location line="+5" />
+        <source>Framework</source>
+        <translation>Framework</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Theme Engine</source>
+        <translation>Theme-Engine</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>Executable</source>
+        <translation>Programmdatei</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Package Backends</source>
+        <translation>Paketquellen</translation>
+    </message>
+    <message>
+        <location line="+5" />
+        <source>Arch Linux</source>
+        <translation>Arch Linux</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Pacman &amp; AUR (yay / paru)</source>
+        <translation>Pacman und AUR (yay / paru)</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Flatpak</source>
+        <translation>Flatpak</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Flathub &amp; System Repositories</source>
+        <translation>Flathub und System-Repositorien</translation>
+    </message>
+    <message>
+        <location line="+5" />
+        <source>Credits &amp; License</source>
+        <translation>Mitwirkende und Lizenz</translation>
+    </message>
+    <message>
+        <location line="+5" />
+        <source>License</source>
+        <translation>Lizenz</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>Design &amp; Components</source>
+        <translation>Design und Komponenten</translation>
+    </message>
+</context>
+<context>
+    <name>AppDetailPage</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/pages/AppDetailPage.qml" line="+16" />
+        <source>App Details</source>
+        <translation>App-Details</translation>
+    </message>
+    <message>
+        <location line="+43" />
+        <location line="+2" />
+        <source>No description available.</source>
+        <translation>Keine Beschreibung verfügbar.</translation>
+    </message>
+    <message>
+        <location line="+91" />
+        <source>Loading package details...</source>
+        <translation>Paketdetails werden geladen …</translation>
+    </message>
+    <message>
+        <location line="+92" />
+        <location line="+266" />
+        <source>Verified</source>
+        <translation>Verifiziert</translation>
+    </message>
+    <message>
+        <location line="-240" />
+        <source>%1 installs, %2 in the last month</source>
+        <translation>%1 Installationen, %2 im letzten Monat</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>%1 installs</source>
+        <translation>%1 Installationen</translation>
+    </message>
+    <message>
+        <location line="+20" />
+        <location line="+12" />
+        <location line="+2" />
+        <source>Flathub (System)</source>
+        <translation>Flathub (System)</translation>
+    </message>
+    <message>
+        <location line="-14" />
+        <location line="+3" />
+        <location line="+2" />
+        <source>Flathub (User)</source>
+        <translation>Flathub (Benutzer)</translation>
+    </message>
+    <message>
+        <location line="+24" />
+        <source>Install</source>
+        <translation>Installieren</translation>
+    </message>
+    <message>
+        <location line="+23" />
+        <source>View Logs</source>
+        <translation>Protokoll anzeigen</translation>
+    </message>
+    <message>
+        <location line="+27" />
+        <source>Open</source>
+        <translation>Öffnen</translation>
+    </message>
+    <message>
+        <location line="+19" />
+        <source>Previews</source>
+        <translation>Vorschauen</translation>
+    </message>
+    <message>
+        <location line="+97" />
+        <location line="+304" />
+        <source>Download Size</source>
+        <translation>Downloadgröße</translation>
+    </message>
+    <message>
+        <location line="-280" />
+        <source>Community</source>
+        <translation>Community</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Publisher</source>
+        <translation>Herausgeber</translation>
+    </message>
+    <message>
+        <location line="+30" />
+        <location line="+231" />
+        <source>Installed Size</source>
+        <translation>Installierte Größe</translation>
+    </message>
+    <message>
+        <location line="-204" />
+        <source>Everyone</source>
+        <translation>Alle Altersgruppen</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>%1 flagged</source>
+        <translation>%1 markiert</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Content Rating</source>
+        <translation>Altersfreigabe</translation>
+    </message>
+    <message>
+        <location line="+56" />
+        <source>Show less</source>
+        <translation>Weniger anzeigen</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Show more</source>
+        <translation>Mehr anzeigen</translation>
+    </message>
+    <message>
+        <location line="+42" />
+        <source>Permissions</source>
+        <translation>Berechtigungen</translation>
+    </message>
+    <message>
+        <location line="+8" />
+        <source>What this application is allowed to access outside its sandbox.</source>
+        <translation>Worauf diese Anwendung außerhalb ihrer Sandbox zugreifen darf.</translation>
+    </message>
+    <message>
+        <location line="+56" />
+        <source>Information</source>
+        <translation>Informationen</translation>
+    </message>
+    <message>
+        <location line="+13" />
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location line="+11" />
+        <source>Repository</source>
+        <translation>Repositorium</translation>
+    </message>
+    <message>
+        <location line="+38" />
+        <source>Build Date</source>
+        <translation>Build-Datum</translation>
+    </message>
+    <message>
+        <location line="+15" />
+        <source>Install Reason</source>
+        <translation>Installationsgrund</translation>
+    </message>
+    <message>
+        <location line="+15" />
+        <source>Votes</source>
+        <translation>Stimmen</translation>
+    </message>
+    <message>
+        <location line="+13" />
+        <source>Popularity</source>
+        <translation>Beliebtheit</translation>
+    </message>
+    <message>
+        <location line="+13" />
+        <source>Maintainer</source>
+        <translation>Maintainer</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Packager</source>
+        <translation>Paketierer</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Orphaned</source>
+        <translation>Verwaist</translation>
+    </message>
+    <message>
+        <location line="+9" />
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Flagged out of date</source>
+        <translation>Als veraltet markiert</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>URL</source>
+        <translation>URL</translation>
+    </message>
+    <message>
+        <location line="+21" />
+        <source>Licenses</source>
+        <translation>Lizenzen</translation>
+    </message>
+    <message>
+        <location line="+15" />
+        <source>Provides</source>
+        <translation>Stellt bereit</translation>
+    </message>
+    <message>
+        <location line="+24" />
+        <source>Depends On (%1)</source>
+        <translation>Hängt ab von (%1)</translation>
+    </message>
+    <message>
+        <location line="+67" />
+        <source>Required By (%1)</source>
+        <translation>Benötigt von (%1)</translation>
+    </message>
+    <message>
+        <location line="+84" />
+        <source>PKGBUILD</source>
+        <translation>PKGBUILD</translation>
+    </message>
+    <message>
+        <location line="+23" />
+        <source>AUR packages are built from a script that runs on your machine. Review it before installing.</source>
+        <translation>AUR-Pakete werden aus einem Skript gebaut, das auf dem eigenen Rechner läuft. Vor der Installation prüfen.</translation>
+    </message>
+    <message>
+        <location line="+33" />
+        <source>The build script could not be loaded.</source>
+        <translation>Das Build-Skript konnte nicht geladen werden.</translation>
+    </message>
+    <message>
+        <location line="+36" />
+        <source>Version %1</source>
+        <translation>Version %1</translation>
+    </message>
+    <message>
+        <location line="+9" />
+        <source>Built %1</source>
+        <translation>Gebaut %1</translation>
+    </message>
+</context>
+<context>
+    <name>AppImagePage</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/pages/AppImagePage.qml" line="+16" />
+        <source>AppImage installer</source>
+        <translation>AppImage-Installer</translation>
+    </message>
+    <message>
+        <location line="+74" />
+        <source>Drop .AppImage File to Install!</source>
+        <translation>AppImage-Datei zum Installieren ablegen!</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Drag &amp; Drop .AppImage file here to Install</source>
+        <translation>AppImage-Datei zum Installieren hierher ziehen</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>Extracts icon, sets executable permissions, &amp; registers .desktop in ~/.local/share/applications</source>
+        <translation>Extrahiert das Symbol, setzt Ausführungsrechte und legt einen .desktop-Eintrag in ~/.local/share/applications an</translation>
+    </message>
+    <message>
+        <location line="+11" />
+        <source>Installed AppImages (%1)</source>
+        <translation>Installierte AppImages (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>AppImagePlugin</name>
+    <message>
+        <location filename="../src/marketplace/plugins/appimageplugin.cpp" line="+84" />
+        <source>new version available</source>
+        <translation>neue Version verfügbar</translation>
+    </message>
+    <message>
+        <location line="+12" />
+        <source>appimageupdatetool is not installed, AppImages cannot be updated</source>
+        <translation>appimageupdatetool ist nicht installiert, AppImages können nicht aktualisiert werden</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>No installed AppImage matches %1</source>
+        <translation>Kein installiertes AppImage passt zu %1</translation>
+    </message>
+</context>
+<context>
+    <name>ExplorePage</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/pages/ExplorePage.qml" line="+16" />
+        <source>Explore</source>
+        <translation>Entdecken</translation>
+    </message>
+    <message>
+        <location line="+14" />
+        <source>Popular on Flathub</source>
+        <translation>Beliebt auf Flathub</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Trending</source>
+        <translation>Im Trend</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Recently updated</source>
+        <translation>Kürzlich aktualisiert</translation>
+    </message>
+    <message>
+        <location line="+135" />
+        <source>Search Flatpak, Pacman, AUR...</source>
+        <translation>Flatpak, Pacman, AUR durchsuchen …</translation>
+    </message>
+    <message>
+        <location line="+74" />
+        <source>All</source>
+        <translation>Alle</translation>
+    </message>
+    <message>
+        <location line="+50" />
+        <source>Categories</source>
+        <translation>Kategorien</translation>
+    </message>
+    <message>
+        <location line="+39" />
+        <source>Photo &amp; Video</source>
+        <translation>Foto und Video</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Music &amp; Audio</source>
+        <translation>Musik und Audio</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Productivity</source>
+        <translation>Produktivität</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Communication &amp; News</source>
+        <translation>Kommunikation und Nachrichten</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Education &amp; Science</source>
+        <translation>Bildung und Wissenschaft</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Games</source>
+        <translation>Spiele</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Utilities</source>
+        <translation>Dienstprogramme</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Development</source>
+        <translation>Entwicklung</translation>
+    </message>
+    <message>
+        <location line="+243" />
+        <source>Loading recommendations...</source>
+        <translation>Empfehlungen werden geladen …</translation>
+    </message>
+    <message>
+        <location line="+26" />
+        <source>Explore packages</source>
+        <translation>Pakete entdecken</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>Search for an app or select a category to get started.</source>
+        <translation>Nach einer App suchen oder eine Kategorie wählen.</translation>
+    </message>
+    <message>
+        <location line="+25" />
+        <source>No packages found</source>
+        <translation>Keine Pakete gefunden</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>Try searching with different keywords or switching sources.</source>
+        <translation>Andere Suchbegriffe oder eine andere Paketquelle versuchen.</translation>
+    </message>
+    <message>
+        <location line="+23" />
+        <source>Loading %1 apps...</source>
+        <translation>%1-Apps werden geladen …</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Searching packages catalog...</source>
+        <translation>Paketkatalog wird durchsucht …</translation>
+    </message>
+    <message>
+        <location line="+175" />
+        <source>Loading more packages...</source>
+        <translation>Weitere Pakete werden geladen …</translation>
+    </message>
+</context>
+<context>
+    <name>InstalledPage</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/pages/InstalledPage.qml" line="+16" />
+        <source>Installed apps</source>
+        <translation>Installierte Apps</translation>
+    </message>
+    <message>
+        <location line="+59" />
+        <source>%1 Installed Applications</source>
+        <translation>%1 installierte Anwendungen</translation>
+    </message>
+    <message>
+        <location line="+18" />
+        <source>Logs</source>
+        <translation>Protokoll</translation>
+    </message>
+    <message>
+        <location line="+25" />
+        <source>Loading installed applications...</source>
+        <translation>Installierte Anwendungen werden geladen …</translation>
+    </message>
+    <message>
+        <location line="+147" />
+        <source>Loading more installed applications...</source>
+        <translation>Weitere installierte Anwendungen werden geladen …</translation>
+    </message>
+</context>
+<context>
+    <name>LogsPage</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/pages/LogsPage.qml" line="+16" />
+        <source>Installation logs</source>
+        <translation>Installationsprotokoll</translation>
+    </message>
+    <message>
+        <location line="+34" />
+        <source>Performing package operation...</source>
+        <translation>Paketvorgang läuft …</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>System idle / Last operation completed</source>
+        <translation>System im Leerlauf / letzter Vorgang abgeschlossen</translation>
+    </message>
+    <message>
+        <location line="+9" />
+        <source>Progress: %1%</source>
+        <translation>Fortschritt: %1 %</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Total logged entries: %1</source>
+        <translation>Protokollierte Einträge: %1</translation>
+    </message>
+    <message>
+        <location line="+17" />
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location line="+85" />
+        <source>No logs yet. Output from installs, removals, and updates will appear here.</source>
+        <translation>Noch keine Einträge. Ausgaben von Installationen, Entfernungen und Updates erscheinen hier.</translation>
+    </message>
+</context>
+<context>
+    <name>MarketSettingsPage</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/pages/MarketSettingsPage.qml" line="+16" />
+        <source>Marketplace Settings</source>
+        <translation>Marktplatz-Einstellungen</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>App Sources</source>
+        <translation>Paketquellen</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Flatpak (Flathub &amp; System)</source>
+        <translation>Flatpak (Flathub und System)</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Enable Flathub and Flatpak package management</source>
+        <translation>Paketverwaltung über Flathub und Flatpak aktivieren</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>flatpak dependency is not installed on this system</source>
+        <translation>flatpak ist auf diesem System nicht installiert</translation>
+    </message>
+    <message>
+        <location line="+13" />
+        <source>Pacman (Arch Linux)</source>
+        <translation>Pacman (Arch Linux)</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Enable native Arch Linux package management</source>
+        <translation>Native Arch-Linux-Paketverwaltung aktivieren</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>pacman dependency is not installed on this system</source>
+        <translation>pacman ist auf diesem System nicht installiert</translation>
+    </message>
+    <message>
+        <location line="+13" />
+        <source>Arch User Repository (AUR)</source>
+        <translation>Arch User Repository (AUR)</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Enable AUR packages via yay / paru helper</source>
+        <translation>AUR-Pakete über yay / paru aktivieren</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>paru or yay helper dependency is not installed on this system</source>
+        <translation>paru oder yay ist auf diesem System nicht installiert</translation>
+    </message>
+    <message>
+        <location line="+14" />
+        <source>AppImage Installer</source>
+        <translation>AppImage-Installer</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Enable AppImage drag &amp; drop installer &amp; desktop integration</source>
+        <translation>AppImage-Installation per Drag-and-drop und Desktop-Integration aktivieren</translation>
+    </message>
+    <message>
+        <location line="+12" />
+        <source>System Tray &amp; Background Daemon</source>
+        <translation>System-Tray und Hintergrunddienst</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Enable System Tray Icon</source>
+        <translation>Symbol im System-Tray anzeigen</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Show status and quick actions in the system tray / notification area</source>
+        <translation>Status und Schnellaktionen im System-Tray anzeigen</translation>
+    </message>
+    <message>
+        <location line="+9" />
+        <source>Close Window to Tray</source>
+        <translation>Fenster in den Tray schließen</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Keep Foundry running in the background when the main window is closed</source>
+        <translation>Foundry im Hintergrund weiterlaufen lassen, wenn das Fenster geschlossen wird</translation>
+    </message>
+    <message>
+        <location line="+12" />
+        <source>Start Minimized on Boot</source>
+        <translation>Beim Anmelden minimiert starten</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Launch Foundry silently in the system tray on login (~/.config/autostart)</source>
+        <translation>Foundry beim Anmelden unsichtbar im System-Tray starten (~/.config/autostart)</translation>
+    </message>
+    <message>
+        <location line="+10" />
+        <source>Automated Update Checks &amp; Notifications</source>
+        <translation>Automatische Update-Prüfungen und Benachrichtigungen</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Check Frequency</source>
+        <translation>Prüfintervall</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Manual updates only (scheduled checks disabled)</source>
+        <translation>Nur manuelle Updates (geplante Prüfungen deaktiviert)</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Check for updates every %1 %2</source>
+        <translation>Alle %1 %2 nach Updates suchen</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>hour</source>
+        <translation>Stunde</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>hours</source>
+        <translation>Stunden</translation>
+    </message>
+    <message>
+        <location line="+12" />
+        <source>Notification Threshold</source>
+        <translation>Benachrichtigungsschwelle</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Notify when %1 %2 available</source>
+        <translation>Benachrichtigen ab %1 %2</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>or more update is</source>
+        <translation>verfügbaren Update</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>or more updates are</source>
+        <translation>verfügbaren Updates</translation>
+    </message>
+    <message>
+        <location line="+13" />
+        <source>Use 'caelestia update' for System Updates</source>
+        <translation>'caelestia update' für System-Updates verwenden</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Delegate Pacman and AUR updates to Caelestia CLI (bypasses individual Pacman/AUR checks)</source>
+        <translation>Pacman- und AUR-Updates an die Caelestia-CLI übergeben (einzelne Pacman-/AUR-Prüfungen entfallen)</translation>
+    </message>
+    <message>
+        <location line="+10" />
+        <source>Auto-Update Flatpak Packages</source>
+        <translation>Flatpak-Pakete automatisch aktualisieren</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Automatically download and apply Flathub updates in the background</source>
+        <translation>Flathub-Updates im Hintergrund automatisch laden und anwenden</translation>
+    </message>
+    <message>
+        <location line="+13" />
+        <source>Auto-Update via Caelestia CLI</source>
+        <translation>Automatisches Update über die Caelestia-CLI</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Automatically run 'caelestia update --noconfirm' on scheduled update checks</source>
+        <translation>Bei geplanten Prüfungen automatisch 'caelestia update --noconfirm' ausführen</translation>
+    </message>
+    <message>
+        <location line="+10" />
+        <source>Auto-Update Pacman Packages</source>
+        <translation>Pacman-Pakete automatisch aktualisieren</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Automatically download and apply native system updates in the background</source>
+        <translation>Native System-Updates im Hintergrund automatisch laden und anwenden</translation>
+    </message>
+    <message>
+        <location line="+13" />
+        <source>Auto-Update AUR Packages</source>
+        <translation>AUR-Pakete automatisch aktualisieren</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Automatically rebuild and update AUR packages in the background</source>
+        <translation>AUR-Pakete im Hintergrund automatisch neu bauen und aktualisieren</translation>
+    </message>
+    <message>
+        <location line="+12" />
+        <source>Caelestia Appearance Sync</source>
+        <translation>Caelestia-Erscheinungsbild synchronisieren</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Sync Color Scheme</source>
+        <translation>Farbschema synchronisieren</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Sync colors and dark/light mode with Caelestia theme daemon</source>
+        <translation>Farben und Hell-/Dunkelmodus mit dem Caelestia-Theme-Dienst abgleichen</translation>
+    </message>
+    <message>
+        <location line="+10" />
+        <source>Sync Design Tokens</source>
+        <translation>Design-Tokens synchronisieren</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Sync sizing, padding, and rounding metrics with Caelestia</source>
+        <translation>Größen, Abstände und Rundungen mit Caelestia abgleichen</translation>
+    </message>
+    <message>
+        <location line="+10" />
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Last Update Check</source>
+        <translation>Letzte Update-Prüfung</translation>
+    </message>
+    <message>
+        <location line="+8" />
+        <source>Pending Updates</source>
+        <translation>Ausstehende Updates</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>%1 available</source>
+        <translation>%1 verfügbar</translation>
+    </message>
+</context>
+<context>
+    <name>PackageManager</name>
+    <message>
+        <location filename="../src/marketplace/packagemanager.cpp" line="+97" />
+        <source>checkupdates is missing, install pacman-contrib to see Pacman updates</source>
+        <translation>checkupdates fehlt – pacman-contrib installieren, um Pacman-Updates zu sehen</translation>
+    </message>
+    <message>
+        <location line="+4" />
+        <source>No AUR helper found, install paru or yay to manage AUR packages</source>
+        <translation>Kein AUR-Helfer gefunden – paru oder yay installieren, um AUR-Pakete zu verwalten</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>appimageupdatetool is missing, AppImages are not checked for updates</source>
+        <translation>appimageupdatetool fehlt – AppImages werden nicht auf Updates geprüft</translation>
+    </message>
+    <message>
+        <location line="+410" />
+        <source>Successfully installed %1</source>
+        <translation>%1 erfolgreich installiert</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Cancelled the installation of %1</source>
+        <translation>Installation von %1 abgebrochen</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Failed to install %1</source>
+        <translation>%1 konnte nicht installiert werden</translation>
+    </message>
+    <message>
+        <location line="+46" />
+        <source>Successfully updated %1</source>
+        <translation>%1 erfolgreich aktualisiert</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Cancelled the update of %1</source>
+        <translation>Update von %1 abgebrochen</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Failed to update %1</source>
+        <translation>%1 konnte nicht aktualisiert werden</translation>
+    </message>
+    <message>
+        <location line="+43" />
+        <source>Successfully uninstalled %1</source>
+        <translation>%1 erfolgreich entfernt</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Cancelled the removal of %1</source>
+        <translation>Entfernen von %1 abgebrochen</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Failed to uninstall %1</source>
+        <translation>%1 konnte nicht entfernt werden</translation>
+    </message>
+    <message>
+        <location line="+166" />
+        <source>All packages updated successfully</source>
+        <translation>Alle Pakete erfolgreich aktualisiert</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Cancelled the update</source>
+        <translation>Update abgebrochen</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Some updates could not be applied</source>
+        <translation>Einige Updates konnten nicht angewendet werden</translation>
+    </message>
+</context>
+<context>
+    <name>PageCompRegistry</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/PageCompRegistry.qml" line="+112" />
+        <source>Page under construction</source>
+        <translation>Seite im Aufbau</translation>
+    </message>
+    <message>
+        <location line="+7" />
+        <source>This page will be available in a future update.</source>
+        <translation>Diese Seite wird in einer künftigen Version verfügbar sein.</translation>
+    </message>
+</context>
+<context>
+    <name>PageRegistry</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/PageRegistry.qml" line="+11" />
+        <source>Explore</source>
+        <translation>Entdecken</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Browse packages</source>
+        <translation>Pakete durchsuchen</translation>
+    </message>
+    <message>
+        <location line="+4" />
+        <source>AppImage installer</source>
+        <translation>AppImage-Installer</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Drag and drop AppImages to install</source>
+        <translation>AppImages zum Installieren hierher ziehen</translation>
+    </message>
+    <message>
+        <location line="+5" />
+        <source>Installed apps</source>
+        <translation>Installierte Apps</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Manage installed packages</source>
+        <translation>Installierte Pakete verwalten</translation>
+    </message>
+    <message>
+        <location line="+4" />
+        <source>Updates</source>
+        <translation>Updates</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>System and package updates</source>
+        <translation>System- und Paket-Updates</translation>
+    </message>
+    <message>
+        <location line="+5" />
+        <source>About</source>
+        <translation>Über</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Versioning and credits</source>
+        <translation>Version und Mitwirkende</translation>
+    </message>
+    <message>
+        <location line="+4" />
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Toggle backends, control theming</source>
+        <translation>Paketquellen und Erscheinungsbild steuern</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/marketplace/plugins/flatpakplugin.cpp" line="+406" />
+        <source>Network access</source>
+        <translation>Netzwerkzugriff</translation>
+    </message>
+    <message>
+        <location line="+4" />
+        <source>Legacy X11 windowing system</source>
+        <translation>Veraltetes X11-Fenstersystem</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Wayland windowing system</source>
+        <translation>Wayland-Fenstersystem</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>X11 windowing system as fallback</source>
+        <translation>X11-Fenstersystem als Rückfallebene</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Full session bus access</source>
+        <translation>Voller Zugriff auf den Session-Bus</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Full system bus access</source>
+        <translation>Voller Zugriff auf den System-Bus</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>SSH agent</source>
+        <translation>SSH-Agent</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>GPG agent</source>
+        <translation>GPG-Agent</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Printing</source>
+        <translation>Drucken</translation>
+    </message>
+    <message>
+        <location line="+4" />
+        <source>All devices</source>
+        <translation>Alle Geräte</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>GPU acceleration</source>
+        <translation>GPU-Beschleunigung</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Input devices</source>
+        <translation>Eingabegeräte</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Virtual machines</source>
+        <translation>Virtuelle Maschinen</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Shared memory</source>
+        <translation>Gemeinsamer Speicher</translation>
+    </message>
+    <message>
+        <location line="+14" />
+        <source>All system files, read only</source>
+        <translation>Alle Systemdateien, nur lesend</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>All system files</source>
+        <translation>Alle Systemdateien</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>System libraries and binaries</source>
+        <translation>Systembibliotheken und -programme</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>System configuration in /etc</source>
+        <translation>Systemkonfiguration in /etc</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Your home folder, read only</source>
+        <translation>Persönlicher Ordner, nur lesend</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Your home folder</source>
+        <translation>Persönlicher Ordner</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Folder: %1</source>
+        <translation>Ordner: %1</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Path: %1</source>
+        <translation>Pfad: %1</translation>
+    </message>
+</context>
+<context>
+    <name>UpdatesPage</name>
+    <message>
+        <location filename="../qml/qs/modules/astra/pages/UpdatesPage.qml" line="+16" />
+        <source>Updates</source>
+        <translation>Updates</translation>
+    </message>
+    <message>
+        <location line="+69" />
+        <source>%1 Updates Available</source>
+        <translation>%1 Updates verfügbar</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>System is up to date</source>
+        <translation>System ist aktuell</translation>
+    </message>
+    <message>
+        <location line="+18" />
+        <source>Logs</source>
+        <translation>Protokoll</translation>
+    </message>
+    <message>
+        <location line="+9" />
+        <source>Update All</source>
+        <translation>Alle aktualisieren</translation>
+    </message>
+    <message>
+        <location line="+66" />
+        <source>Applying updates...</source>
+        <translation>Updates werden angewendet …</translation>
+    </message>
+    <message>
+        <location line="+1" />
+        <source>Checking for updates...</source>
+        <translation>Suche nach Updates …</translation>
+    </message>
+    <message>
+        <location line="+101" />
+        <source>Update to </source>
+        <translation>Aktualisieren auf </translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Update available</source>
+        <translation>Update verfügbar</translation>
+    </message>
+    <message>
+        <location line="+11" />
+        <source>Update</source>
+        <translation>Aktualisieren</translation>
+    </message>
+    <message>
+        <location line="+26" />
+        <source>Recent activity</source>
+        <translation>Letzte Aktivität</translation>
+    </message>
+    <message>
+        <location line="+48" />
+        <source>Installed %1</source>
+        <translation>%1 installiert</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Failed to install %1</source>
+        <translation>%1 konnte nicht installiert werden</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Updated %1</source>
+        <translation>%1 aktualisiert</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Failed to update %1</source>
+        <translation>%1 konnte nicht aktualisiert werden</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>Removed %1</source>
+        <translation>%1 entfernt</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>Failed to remove %1</source>
+        <translation>%1 konnte nicht entfernt werden</translation>
+    </message>
+    <message>
+        <location line="+2" />
+        <source>System update completed</source>
+        <translation>System-Update abgeschlossen</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>System update failed</source>
+        <translation>System-Update fehlgeschlagen</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Problem

Every user visible string is already wrapped in `qsTr()` / `tr()` — 223 of them — but nothing ever collected or loaded them: no `.ts` files, no `qt_add_translations()`, no `QTranslator`. The interface is English only, and the wrapping suggests otherwise.

Two strings could not be translated even in principle: the source filter chip (`All`, `Flatpak`, `Pacman`, `AUR`) and the category pills used their label as the lookup key, so translating the label would have broken the filter and the Flathub category query.

## Change

- `translations/foundry_de.ts` with a complete German translation (223 strings, 0 unfinished).
- `qt_add_translations()` compiles the `.qm` into the binary under `:/i18n`, guarded by `find_package(Qt6 QUIET COMPONENTS LinguistTools)`; without the tools the build prints "Foundry is built without translations" and produces the English binary as before.
- `installTranslations()` loads the translation for the system locale at startup, for the GUI and the CLI.
- The filter chip and the category pills carry a separate translated label, so `activeFilter` and the Flathub category names stay the English keys the backends expect.
- CI installs `qt6-tools`, so the translations are built there and in the release workflow (which already had it).
- README and CONTRIBUTING document `update_translations` and how to add a language.

## Testing

```
$ lupdate qml src -ts translations/foundry_de.ts
    Found 223 source text(s)
$ lrelease translations/foundry_de.ts
    Generated 223 translation(s) (223 finished and 0 unfinished)
```

Running with `LANG=de_DE.UTF-8` shows the translated interface — "Entdecken / Pakete durchsuchen", "AppImage-Installer", "Installierte Apps", "Beliebt auf Flathub", "Im Trend", the filter chip as "Alle" — while backend names (Flatpak, Pacman, AUR) stay untranslated (screenshots from the running app). With any other locale the interface is unchanged.

Both build modes verified: with the Linguist tools the `.qm` is generated and embedded, without them the configure step reports the fallback and the build succeeds. `ctest` passes.