### PR TITLE
feat(flatpak): manage remotes from the settings page

### DIFF
--- a/qml/qs/modules/astra/pages/MarketSettingsPage.qml
+++ b/qml/qs/modules/astra/pages/MarketSettingsPage.qml
@@ -15,6 +15,31 @@ PageBase {
 
     title: qsTr("Marketplace Settings")
 
+    property var remotes: []
+    property string remoteStatus: ""
+
+    function reloadRemotes(): void {
+        root.remotes = PackageManager.isFlatpakAvailable ? PackageManager.flatpakRemotes() : [];
+    }
+
+    Component.onCompleted: {
+        reloadRemotes();
+    }
+
+    data: [
+        Connections {
+            target: PackageManager
+
+            function onRemotesChanged(): void {
+                root.reloadRemotes();
+            }
+
+            function onRemoteOperationFinished(success, message): void {
+                root.remoteStatus = message;
+            }
+        }
+    ]
+
     Column {
         width: root ? root.width : 0
         spacing: Tokens.spacing.extraSmall / 2
@@ -77,6 +102,193 @@ PageBase {
             onCheckedChanged: {
                 PackageManager.enableAppImage = checked;
             }
+        }
+
+        Item {
+            width: 1
+            height: Tokens.padding.small
+            visible: PackageManager.isFlatpakAvailable
+        }
+
+        SectionHeader {
+            text: qsTr("Flatpak Remotes")
+            visible: PackageManager.isFlatpakAvailable
+        }
+
+        Repeater {
+            id: remotesRepeater
+
+            model: PackageManager.isFlatpakAvailable ? root.remotes : []
+
+            ConnectedRect {
+                id: remoteRow
+
+                required property var modelData
+                required property int index
+
+                width: root.width
+                first: index === 0
+                implicitHeight: remoteLayout.implicitHeight + Tokens.padding.medium * 2
+
+                RowLayout {
+                    id: remoteLayout
+
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.medium
+                    anchors.leftMargin: Tokens.padding.largeIncreased
+                    anchors.rightMargin: Tokens.padding.medium
+                    spacing: Tokens.padding.small
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 0
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Tokens.padding.small
+
+                            StyledText {
+                                text: remoteRow.modelData.title
+                                font: Tokens.font.body.small
+                                color: Colours.palette.m3onSurface
+                                elide: Text.ElideRight
+                            }
+
+                            Rectangle {
+                                implicitWidth: scopeText.implicitWidth + Tokens.padding.small * 2
+                                implicitHeight: scopeText.implicitHeight + Tokens.padding.extraSmall
+                                radius: Tokens.rounding.small
+                                color: Colours.palette.m3secondaryContainer
+
+                                StyledText {
+                                    id: scopeText
+
+                                    anchors.centerIn: parent
+                                    text: remoteRow.modelData.scope === "system" ? qsTr("System") : qsTr("User")
+                                    font: Tokens.font.label.small
+                                    color: Colours.palette.m3onSecondaryContainer
+                                }
+                            }
+
+                            Item { Layout.fillWidth: true }
+                        }
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: remoteRow.modelData.url
+                            font: Tokens.font.label.small
+                            color: Colours.palette.m3outline
+                            elide: Text.ElideRight
+                        }
+                    }
+
+                    IconButton {
+                        icon: "delete"
+                        type: IconButton.Text
+                        inactiveOnColour: Colours.palette.m3error
+                        activeOnColour: Colours.palette.m3error
+                        Layout.alignment: Qt.AlignVCenter
+                        onClicked: PackageManager.removeFlatpakRemote(remoteRow.modelData.name, remoteRow.modelData.scope)
+                    }
+                }
+            }
+        }
+
+        ConnectedRect {
+            id: addRemoteRow
+
+            width: root.width
+            visible: PackageManager.isFlatpakAvailable
+            first: root.remotes.length === 0
+            last: true
+            implicitHeight: addRemoteLayout.implicitHeight + Tokens.padding.medium * 2
+
+            RowLayout {
+                id: addRemoteLayout
+
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                anchors.leftMargin: Tokens.padding.largeIncreased
+                anchors.rightMargin: Tokens.padding.medium
+                spacing: Tokens.padding.small
+
+                StyledRect {
+                    Layout.preferredWidth: 140
+                    implicitHeight: 36
+                    radius: Tokens.rounding.full
+                    color: Colours.tPalette.m3surfaceContainerHigh
+
+                    TextFieldBase {
+                        id: remoteNameField
+
+                        anchors.fill: parent
+                        leftPadding: Tokens.padding.medium
+                        rightPadding: Tokens.padding.medium
+                    }
+
+                    StyledText {
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.leftMargin: Tokens.padding.medium
+                        visible: remoteNameField.text.length === 0
+                        text: qsTr("Name")
+                        font: Tokens.font.body.small
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+                }
+
+                StyledRect {
+                    Layout.fillWidth: true
+                    implicitHeight: 36
+                    radius: Tokens.rounding.full
+                    color: Colours.tPalette.m3surfaceContainerHigh
+
+                    TextFieldBase {
+                        id: remoteUrlField
+
+                        anchors.fill: parent
+                        leftPadding: Tokens.padding.medium
+                        rightPadding: Tokens.padding.medium
+                    }
+
+                    StyledText {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.leftMargin: Tokens.padding.medium
+                        anchors.rightMargin: Tokens.padding.medium
+                        visible: remoteUrlField.text.length === 0
+                        text: qsTr("Repository URL or .flatpakrepo file")
+                        font: Tokens.font.body.small
+                        color: Colours.palette.m3onSurfaceVariant
+                        elide: Text.ElideRight
+                    }
+                }
+
+                IconTextButton {
+                    icon: "add"
+                    text: qsTr("Add")
+                    type: ButtonBase.Tonal
+                    enabled: remoteNameField.text.trim().length > 0 && remoteUrlField.text.trim().length > 0
+                    Layout.alignment: Qt.AlignVCenter
+                    onClicked: {
+                        PackageManager.addFlatpakRemote(remoteNameField.text, remoteUrlField.text, "user");
+                        remoteNameField.clear();
+                        remoteUrlField.clear();
+                    }
+                }
+            }
+        }
+
+        StyledText {
+            width: root.width
+            visible: PackageManager.isFlatpakAvailable && root.remoteStatus !== ""
+            text: root.remoteStatus
+            font: Tokens.font.label.small
+            color: Colours.palette.m3onSurfaceVariant
+            leftPadding: Tokens.padding.largeIncreased
+            topPadding: Tokens.spacing.extraSmall
+            wrapMode: Text.WordWrap
         }
 
         Item { width: 1; height: Tokens.padding.small }

--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -700,6 +700,67 @@ void PackageManager::fetchCollectionAsync(const QString& collection, int limit) 
     }));
 }
 
+QVariantList PackageManager::flatpakRemotes() const {
+    return m_flatpakPlugin ? m_flatpakPlugin->getRemotes() : QVariantList();
+}
+
+void PackageManager::addFlatpakRemote(const QString& name, const QString& url, const QString& scope) {
+    if (!m_flatpakPlugin || name.trimmed().isEmpty() || url.trimmed().isEmpty()) return;
+
+    const QString remoteName = name.trimmed();
+    const QString remoteUrl = url.trimmed();
+    appendLog(QStringLiteral("[%1] Adding Flatpak remote %2 (%3)").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), remoteName, scope));
+
+    auto* watcher = new QFutureWatcher<QString>(this);
+    connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher, remoteName] {
+        const QString error = watcher->result();
+        watcher->deleteLater();
+
+        if (error.isEmpty()) {
+            appendLog(QStringLiteral("[%1] Added Flatpak remote %2").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), remoteName));
+            emit remotesChanged();
+            emit remoteOperationFinished(true, tr("Added remote %1").arg(remoteName));
+        } else {
+            appendLog(QStringLiteral("[%1] %2").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), error));
+            emit remoteOperationFinished(false, error);
+        }
+    });
+
+    watcher->setFuture(QtConcurrent::run(&m_pluginPool, [this, remoteName, remoteUrl, scope] {
+        QString error;
+        if (m_flatpakPlugin->addRemote(remoteName, remoteUrl, scope, &error)) return QString();
+        return error.isEmpty() ? tr("Could not add remote %1").arg(remoteName) : error;
+    }));
+}
+
+void PackageManager::removeFlatpakRemote(const QString& name, const QString& scope) {
+    if (!m_flatpakPlugin || name.trimmed().isEmpty()) return;
+
+    const QString remoteName = name.trimmed();
+    appendLog(QStringLiteral("[%1] Removing Flatpak remote %2 (%3)").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), remoteName, scope));
+
+    auto* watcher = new QFutureWatcher<QString>(this);
+    connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher, remoteName] {
+        const QString error = watcher->result();
+        watcher->deleteLater();
+
+        if (error.isEmpty()) {
+            appendLog(QStringLiteral("[%1] Removed Flatpak remote %2").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), remoteName));
+            emit remotesChanged();
+            emit remoteOperationFinished(true, tr("Removed remote %1").arg(remoteName));
+        } else {
+            appendLog(QStringLiteral("[%1] %2").arg(QTime::currentTime().toString(QStringLiteral("HH:mm:ss")), error));
+            emit remoteOperationFinished(false, error);
+        }
+    });
+
+    watcher->setFuture(QtConcurrent::run(&m_pluginPool, [this, remoteName, scope] {
+        QString error;
+        if (m_flatpakPlugin->removeRemote(remoteName, scope, &error)) return QString();
+        return error.isEmpty() ? tr("Could not remove remote %1").arg(remoteName) : error;
+    }));
+}
+
 void PackageManager::fetchBuildScriptAsync(const QString& packageId) {
     if (packageId.isEmpty() || !m_aurPlugin) return;
 

--- a/src/marketplace/packagemanager.hpp
+++ b/src/marketplace/packagemanager.hpp
@@ -99,6 +99,9 @@ public:
     Q_INVOKABLE void fetchPackageDetailsAsync(const QString& packageId, const QString& backend = QString());
     Q_INVOKABLE void fetchCollectionAsync(const QString& collection, int limit = 12);
     Q_INVOKABLE void fetchBuildScriptAsync(const QString& packageId);
+    Q_INVOKABLE QVariantList flatpakRemotes() const;
+    Q_INVOKABLE void addFlatpakRemote(const QString& name, const QString& url, const QString& scope = QStringLiteral("user"));
+    Q_INVOKABLE void removeFlatpakRemote(const QString& name, const QString& scope = QStringLiteral("user"));
     Q_INVOKABLE QVariantList checkForUpdates();
     Q_INVOKABLE void checkForUpdatesAsync();
     Q_INVOKABLE void updateAllPackages();
@@ -132,6 +135,8 @@ signals:
     void packageDetailsReady(const QVariantMap& details);
     void collectionReady(const QString& collection, const QVariantList& apps);
     void buildScriptReady(const QString& packageId, const QString& script);
+    void remotesChanged();
+    void remoteOperationFinished(bool success, const QString& message);
 
 private:
     void setBusy(bool busy);

--- a/src/marketplace/plugins/flatpakplugin.cpp
+++ b/src/marketplace/plugins/flatpakplugin.cpp
@@ -25,6 +25,7 @@ bool FlatpakPlugin::isAvailable() const {
 
 namespace {
 constexpr int kQueryTimeoutMs = 15000;
+constexpr int kOperationTimeoutMs = 120000;
 constexpr int kSearchTimeoutMs = 5000;
 constexpr int kDetailsTimeoutMs = 10000;
 
@@ -189,6 +190,68 @@ QVariantList FlatpakPlugin::parseCollectionHits(const QByteArray& payload, QSet<
         results.append(item);
     }
     return results;
+}
+
+QVariantList FlatpakPlugin::parseRemotesOutput(const QString& output, const QString& scope) {
+    QVariantList remotes;
+
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    for (const QString& line : lines) {
+        const QStringList parts = line.split(QLatin1Char('\t'), Qt::KeepEmptyParts);
+        const QString name = parts.value(0).trimmed();
+        if (name.isEmpty()) continue;
+
+        QVariantMap remote;
+        remote[QStringLiteral("name")] = name;
+        remote[QStringLiteral("title")] = parts.value(1).trimmed().isEmpty() ? name : parts.value(1).trimmed();
+        remote[QStringLiteral("url")] = parts.value(2).trimmed();
+        remote[QStringLiteral("scope")] = scope;
+        remotes.append(remote);
+    }
+    return remotes;
+}
+
+QVariantList FlatpakPlugin::getRemotes() {
+    QVariantList remotes;
+    if (!isAvailable()) return remotes;
+
+    const QStringList scopes{QStringLiteral("user"), QStringLiteral("system")};
+    for (const QString& scope : scopes) {
+        const astra::ProcessResult result = astra::runProcess(
+            QStringLiteral("flatpak"),
+            {QStringLiteral("remotes"), scopeArgument(scope), QStringLiteral("--columns=name,title,url")},
+            kQueryTimeoutMs);
+        remotes.append(parseRemotesOutput(result.output, scope));
+    }
+    return remotes;
+}
+
+bool FlatpakPlugin::addRemote(const QString& name, const QString& url, const QString& scope, QString* error) {
+    if (!isAvailable() || name.isEmpty() || url.isEmpty()) return false;
+
+    const astra::ProcessResult result = astra::runProcess(
+        QStringLiteral("flatpak"),
+        {QStringLiteral("remote-add"), scopeArgument(scope), QStringLiteral("--if-not-exists"), name, url},
+        kOperationTimeoutMs);
+
+    if (!result.succeeded() && error) {
+        *error = result.error.trimmed().isEmpty() ? result.output.trimmed() : result.error.trimmed();
+    }
+    return result.succeeded();
+}
+
+bool FlatpakPlugin::removeRemote(const QString& name, const QString& scope, QString* error) {
+    if (!isAvailable() || name.isEmpty()) return false;
+
+    const astra::ProcessResult result = astra::runProcess(
+        QStringLiteral("flatpak"),
+        {QStringLiteral("remote-delete"), scopeArgument(scope), name},
+        kOperationTimeoutMs);
+
+    if (!result.succeeded() && error) {
+        *error = result.error.trimmed().isEmpty() ? result.output.trimmed() : result.error.trimmed();
+    }
+    return result.succeeded();
 }
 
 QVariantList FlatpakPlugin::getCollection(const QString& collection, int limit) {

--- a/src/marketplace/plugins/flatpakplugin.hpp
+++ b/src/marketplace/plugins/flatpakplugin.hpp
@@ -33,6 +33,12 @@ public:
 
     QVariantList getCollection(const QString& collection, int limit);
 
+    QVariantList getRemotes();
+    bool addRemote(const QString& name, const QString& url, const QString& scope, QString* error = nullptr);
+    bool removeRemote(const QString& name, const QString& scope, QString* error = nullptr);
+
+    static QVariantList parseRemotesOutput(const QString& output, const QString& scope);
+
     static QVariantList permissionEntries(const QJsonObject& permissions);
     static QVariantList parseLocalPermissions(const QString& output);
     static QString formatBytes(qint64 bytes);

--- a/translations/foundry_de.ts
+++ b/translations/foundry_de.ts
@@ -553,7 +553,7 @@
         <translation>Marktplatz-Einstellungen</translation>
     </message>
     <message>
-        <location line="+7" />
+        <location line="+32" />
         <source>App Sources</source>
         <translation>Paketquellen</translation>
     </message>
@@ -613,7 +613,37 @@
         <translation>AppImage-Installation per Drag-and-drop und Desktop-Integration aktivieren</translation>
     </message>
     <message>
-        <location line="+12" />
+        <location line="+16" />
+        <source>Flatpak Remotes</source>
+        <translation>Flatpak-Remotes</translation>
+    </message>
+    <message>
+        <location line="+53" />
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <location line="+0" />
+        <source>User</source>
+        <translation>Benutzer</translation>
+    </message>
+    <message>
+        <location line="+67" />
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <location line="+27" />
+        <source>Repository URL or .flatpakrepo file</source>
+        <translation>Repositorium-URL oder .flatpakrepo-Datei</translation>
+    </message>
+    <message>
+        <location line="+9" />
+        <source>Add</source>
+        <translation>Hinzufügen</translation>
+    </message>
+    <message>
+        <location line="+27" />
         <source>System Tray &amp; Background Daemon</source>
         <translation>System-Tray und Hintergrunddienst</translation>
     </message>
@@ -856,7 +886,27 @@
         <translation>%1 konnte nicht entfernt werden</translation>
     </message>
     <message>
-        <location line="+166" />
+        <location line="+113" />
+        <source>Added remote %1</source>
+        <translation>Remote %1 hinzugefügt</translation>
+    </message>
+    <message>
+        <location line="+10" />
+        <source>Could not add remote %1</source>
+        <translation>Remote %1 konnte nicht hinzugefügt werden</translation>
+    </message>
+    <message>
+        <location line="+18" />
+        <source>Removed remote %1</source>
+        <translation>Remote %1 entfernt</translation>
+    </message>
+    <message>
+        <location line="+10" />
+        <source>Could not remove remote %1</source>
+        <translation>Remote %1 konnte nicht entfernt werden</translation>
+    </message>
+    <message>
+        <location line="+76" />
         <source>All packages updated successfully</source>
         <translation>Alle Pakete erfolgreich aktualisiert</translation>
     </message>
@@ -950,7 +1000,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/marketplace/plugins/flatpakplugin.cpp" line="+406" />
+        <location filename="../src/marketplace/plugins/flatpakplugin.cpp" line="+469" />
         <source>Network access</source>
         <translation>Netzwerkzugriff</translation>
     </message>


### PR DESCRIPTION
## Problem

The Flatpak backend works with whatever remotes are already configured, and the app never shows them. A user with no remote at all sees an empty Flathub search and no explanation, and adding or removing one means `flatpak remote-add` in a terminal.

## Change

- `FlatpakPlugin` gained `getRemotes()`, `addRemote()` and `removeRemote()`. Listing queries the user and the system installation separately and tags each entry with its scope; add uses `--if-not-exists`, and both operations return the error output when flatpak refuses (for example when a remote still has applications installed).
- `PackageManager` exposes them to QML, runs add/remove off the UI thread, logs both, and emits `remotesChanged()` / `remoteOperationFinished(success, message)`.
- The settings page gained a "Flatpak Remotes" section: every configured remote with its title, URL and a User/System badge, a delete button per entry, and a row to add a new remote for the user installation from a name and a repository URL (a plain URL or a `.flatpakrepo` file). The result message of the last operation is shown below.

Removing a system remote goes through flatpak, which asks PolicyKit for authorisation itself.

## Testing

Driven through the plugin against the real flatpak installation on this machine:

```
before:      user GeForceNOW …    user flathub …    system flathub …
addRemote -> true
after add:   user GeForceNOW …    user flathub …    user foundry-test-repo file:///tmp/foundry-test-repo    system flathub …
removeRemote -> true
after remove: user GeForceNOW …   user flathub …    system flathub …
```

The existing remotes were untouched. In the GUI the section lists all three remotes with the correct scope badges and URLs, the add row validates that both fields are filled before enabling the button, and every new string is translated (screenshot from the running app, German locale). `ctest` passes.