### PR TITLE
feat(flatpak): let sandbox permissions be revoked from the detail page

### DIFF
--- a/qml/qs/modules/astra/pages/AppDetailPage.qml
+++ b/qml/qs/modules/astra/pages/AppDetailPage.qml
@@ -682,7 +682,9 @@ PageBase {
 
                 StyledText {
                     Layout.fillWidth: true
-                    text: qsTr("What this application is allowed to access outside its sandbox.")
+                    text: root.isInstalled
+                        ? qsTr("What this application is allowed to access outside its sandbox. Turning one off adds a permission override for your user.")
+                        : qsTr("What this application is allowed to access outside its sandbox.")
                     font: Tokens.font.body.small
                     color: Colours.palette.m3onSurfaceVariant
                     wrapMode: Text.WordWrap
@@ -695,6 +697,7 @@ PageBase {
                         id: permissionRow
 
                         required property var modelData
+                        readonly property bool revoked: !!permissionRow.modelData.revoked
 
                         Layout.fillWidth: true
                         spacing: Tokens.padding.small
@@ -702,15 +705,32 @@ PageBase {
                         MaterialIcon {
                             text: permissionRow.modelData.icon
                             fontStyle: Tokens.font.icon.small
-                            color: permissionRow.modelData.sensitive ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                            color: permissionRow.revoked
+                                ? Colours.palette.m3outline
+                                : (permissionRow.modelData.sensitive ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant)
                         }
 
                         StyledText {
                             Layout.fillWidth: true
-                            text: permissionRow.modelData.label
+                            text: permissionRow.revoked
+                                ? qsTr("%1 (revoked)").arg(permissionRow.modelData.label)
+                                : permissionRow.modelData.label
                             font: Tokens.font.body.medium
-                            color: permissionRow.modelData.sensitive ? Colours.palette.m3error : Colours.palette.m3onSurface
+                            color: permissionRow.revoked
+                                ? Colours.palette.m3outline
+                                : (permissionRow.modelData.sensitive ? Colours.palette.m3error : Colours.palette.m3onSurface)
                             elide: Text.ElideRight
+                        }
+
+                        StyledSwitch {
+                            visible: root.isInstalled && permissionRow.modelData.kind
+                            checked: !permissionRow.revoked
+                            Layout.alignment: Qt.AlignVCenter
+                            onToggled: PackageManager.setFlatpakPermission(root.appData.id || "",
+                                                                           permissionRow.modelData.kind,
+                                                                           permissionRow.modelData.value,
+                                                                           permissionRow.modelData.access || "",
+                                                                           checked)
                         }
                     }
                 }

--- a/src/marketplace/packagemanager.cpp
+++ b/src/marketplace/packagemanager.cpp
@@ -704,6 +704,25 @@ QVariantList PackageManager::flatpakRemotes() const {
     return m_flatpakPlugin ? m_flatpakPlugin->getRemotes() : QVariantList();
 }
 
+void PackageManager::setFlatpakPermission(const QString& packageId, const QString& kind, const QString& value, const QString& access, bool enabled) {
+    if (!m_flatpakPlugin || packageId.isEmpty()) return;
+
+    appendLog(QStringLiteral("[%1] %2 %3 for %4").arg(
+        QTime::currentTime().toString(QStringLiteral("HH:mm:ss")),
+        enabled ? QStringLiteral("Granting") : QStringLiteral("Revoking"),
+        value, packageId));
+
+    auto* watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher, packageId] {
+        watcher->deleteLater();
+        fetchPackageDetailsAsync(packageId, QStringLiteral("Flatpak"));
+    });
+
+    watcher->setFuture(QtConcurrent::run(&m_pluginPool, [this, packageId, kind, value, access, enabled] {
+        return m_flatpakPlugin->setPermission(packageId, kind, value, access, enabled);
+    }));
+}
+
 void PackageManager::addFlatpakRemote(const QString& name, const QString& url, const QString& scope) {
     if (!m_flatpakPlugin || name.trimmed().isEmpty() || url.trimmed().isEmpty()) return;
 

--- a/src/marketplace/packagemanager.hpp
+++ b/src/marketplace/packagemanager.hpp
@@ -100,6 +100,7 @@ public:
     Q_INVOKABLE void fetchCollectionAsync(const QString& collection, int limit = 12);
     Q_INVOKABLE void fetchBuildScriptAsync(const QString& packageId);
     Q_INVOKABLE QVariantList flatpakRemotes() const;
+    Q_INVOKABLE void setFlatpakPermission(const QString& packageId, const QString& kind, const QString& value, const QString& access, bool enabled);
     Q_INVOKABLE void addFlatpakRemote(const QString& name, const QString& url, const QString& scope = QStringLiteral("user"));
     Q_INVOKABLE void removeFlatpakRemote(const QString& name, const QString& scope = QStringLiteral("user"));
     Q_INVOKABLE QVariantList checkForUpdates();

--- a/src/marketplace/plugins/flatpakplugin.cpp
+++ b/src/marketplace/plugins/flatpakplugin.cpp
@@ -192,6 +192,54 @@ QVariantList FlatpakPlugin::parseCollectionHits(const QByteArray& payload, QSet<
     return results;
 }
 
+QMap<QString, QStringList> FlatpakPlugin::parseOverrides(const QString& output) {
+    QMap<QString, QStringList> revoked;
+
+    const QStringList lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    for (const QString& line : lines) {
+        const QString trimmed = line.trimmed();
+        const qsizetype separator = trimmed.indexOf(QLatin1Char('='));
+        if (separator <= 0) continue;
+
+        const QString section = trimmed.left(separator);
+        const QStringList values = trimmed.mid(separator + 1).split(QLatin1Char(';'), Qt::SkipEmptyParts);
+
+        for (const QString& value : values) {
+            if (!value.startsWith(QLatin1Char('!'))) continue;
+            revoked[section].append(value.mid(1).section(QLatin1Char(':'), 0, 0));
+        }
+    }
+    return revoked;
+}
+
+QMap<QString, QStringList> FlatpakPlugin::getOverrides(const QString& packageId) {
+    if (!isAvailable() || packageId.isEmpty()) return {};
+
+    const astra::ProcessResult result = astra::runProcess(
+        QStringLiteral("flatpak"),
+        {QStringLiteral("override"), QStringLiteral("--user"), QStringLiteral("--show"), packageId},
+        kQueryTimeoutMs);
+    return parseOverrides(result.output);
+}
+
+bool FlatpakPlugin::setPermission(const QString& packageId, const QString& kind, const QString& value, const QString& access, bool enabled) {
+    if (!isAvailable() || packageId.isEmpty() || kind.isEmpty() || value.isEmpty()) return false;
+
+    QString flag;
+    if (kind == QStringLiteral("shared")) flag = enabled ? QStringLiteral("--share=") : QStringLiteral("--unshare=");
+    else if (kind == QStringLiteral("socket")) flag = enabled ? QStringLiteral("--socket=") : QStringLiteral("--nosocket=");
+    else if (kind == QStringLiteral("device")) flag = enabled ? QStringLiteral("--device=") : QStringLiteral("--nodevice=");
+    else if (kind == QStringLiteral("filesystem")) flag = enabled ? QStringLiteral("--filesystem=") : QStringLiteral("--nofilesystem=");
+    else return false;
+
+    const QString argument = flag + value + (enabled ? access : QString());
+    const astra::ProcessResult result = astra::runProcess(
+        QStringLiteral("flatpak"),
+        {QStringLiteral("override"), QStringLiteral("--user"), argument, packageId},
+        kQueryTimeoutMs);
+    return result.succeeded();
+}
+
 QVariantList FlatpakPlugin::parseRemotesOutput(const QString& output, const QString& scope) {
     QVariantList remotes;
 
@@ -453,64 +501,74 @@ int flaggedContentCategories(const QJsonObject& details) {
     return -1;
 }
 
-void appendPermission(QVariantList& entries, const QString& label, const QString& icon, bool sensitive) {
-    for (const QVariant& value : entries) {
-        if (value.toMap().value(QStringLiteral("label")).toString() == label) return;
+void appendPermission(QVariantList& entries, const QString& label, const QString& icon, bool sensitive,
+                      const QString& kind, const QString& value, const QString& access = QString()) {
+    for (const QVariant& existing : entries) {
+        if (existing.toMap().value(QStringLiteral("label")).toString() == label) return;
     }
 
     QVariantMap entry;
     entry[QStringLiteral("label")] = label;
     entry[QStringLiteral("icon")] = icon;
     entry[QStringLiteral("sensitive")] = sensitive;
+    entry[QStringLiteral("kind")] = kind;
+    entry[QStringLiteral("value")] = value;
+    entry[QStringLiteral("access")] = access;
+    entry[QStringLiteral("revoked")] = false;
     entries.append(entry);
 }
 
 void appendSharedPermission(QVariantList& entries, const QString& value) {
-    if (value == QStringLiteral("network")) appendPermission(entries, QObject::tr("Network access"), QStringLiteral("public"), false);
+    if (value == QStringLiteral("network")) appendPermission(entries, QObject::tr("Network access"), QStringLiteral("public"), false, QStringLiteral("shared"), value);
 }
 
 void appendSocketPermission(QVariantList& entries, const QString& value) {
-    if (value == QStringLiteral("x11")) appendPermission(entries, QObject::tr("Legacy X11 windowing system"), QStringLiteral("desktop_windows"), true);
-    else if (value == QStringLiteral("wayland")) appendPermission(entries, QObject::tr("Wayland windowing system"), QStringLiteral("desktop_windows"), false);
-    else if (value == QStringLiteral("fallback-x11")) appendPermission(entries, QObject::tr("X11 windowing system as fallback"), QStringLiteral("desktop_windows"), false);
-    else if (value == QStringLiteral("pulseaudio")) appendPermission(entries, QObject::tr("Audio"), QStringLiteral("volume_up"), false);
-    else if (value == QStringLiteral("session-bus")) appendPermission(entries, QObject::tr("Full session bus access"), QStringLiteral("hub"), true);
-    else if (value == QStringLiteral("system-bus")) appendPermission(entries, QObject::tr("Full system bus access"), QStringLiteral("hub"), true);
-    else if (value == QStringLiteral("ssh-auth")) appendPermission(entries, QObject::tr("SSH agent"), QStringLiteral("key"), true);
-    else if (value == QStringLiteral("gpg-agent")) appendPermission(entries, QObject::tr("GPG agent"), QStringLiteral("key"), true);
-    else if (value == QStringLiteral("cups")) appendPermission(entries, QObject::tr("Printing"), QStringLiteral("print"), false);
+    if (value == QStringLiteral("x11")) appendPermission(entries, QObject::tr("Legacy X11 windowing system"), QStringLiteral("desktop_windows"), true, QStringLiteral("socket"), value);
+    else if (value == QStringLiteral("wayland")) appendPermission(entries, QObject::tr("Wayland windowing system"), QStringLiteral("desktop_windows"), false, QStringLiteral("socket"), value);
+    else if (value == QStringLiteral("fallback-x11")) appendPermission(entries, QObject::tr("X11 windowing system as fallback"), QStringLiteral("desktop_windows"), false, QStringLiteral("socket"), value);
+    else if (value == QStringLiteral("pulseaudio")) appendPermission(entries, QObject::tr("Audio"), QStringLiteral("volume_up"), false, QStringLiteral("socket"), value);
+    else if (value == QStringLiteral("session-bus")) appendPermission(entries, QObject::tr("Full session bus access"), QStringLiteral("hub"), true, QStringLiteral("socket"), value);
+    else if (value == QStringLiteral("system-bus")) appendPermission(entries, QObject::tr("Full system bus access"), QStringLiteral("hub"), true, QStringLiteral("socket"), value);
+    else if (value == QStringLiteral("ssh-auth")) appendPermission(entries, QObject::tr("SSH agent"), QStringLiteral("key"), true, QStringLiteral("socket"), value);
+    else if (value == QStringLiteral("gpg-agent")) appendPermission(entries, QObject::tr("GPG agent"), QStringLiteral("key"), true, QStringLiteral("socket"), value);
+    else if (value == QStringLiteral("cups")) appendPermission(entries, QObject::tr("Printing"), QStringLiteral("print"), false, QStringLiteral("socket"), value);
 }
 
 void appendDevicePermission(QVariantList& entries, const QString& value) {
-    if (value == QStringLiteral("all")) appendPermission(entries, QObject::tr("All devices"), QStringLiteral("devices_other"), true);
-    else if (value == QStringLiteral("dri")) appendPermission(entries, QObject::tr("GPU acceleration"), QStringLiteral("memory"), false);
-    else if (value == QStringLiteral("input")) appendPermission(entries, QObject::tr("Input devices"), QStringLiteral("keyboard"), false);
-    else if (value == QStringLiteral("kvm")) appendPermission(entries, QObject::tr("Virtual machines"), QStringLiteral("developer_board"), true);
-    else if (value == QStringLiteral("shm")) appendPermission(entries, QObject::tr("Shared memory"), QStringLiteral("memory"), false);
+    if (value == QStringLiteral("all")) appendPermission(entries, QObject::tr("All devices"), QStringLiteral("devices_other"), true, QStringLiteral("device"), value);
+    else if (value == QStringLiteral("dri")) appendPermission(entries, QObject::tr("GPU acceleration"), QStringLiteral("memory"), false, QStringLiteral("device"), value);
+    else if (value == QStringLiteral("input")) appendPermission(entries, QObject::tr("Input devices"), QStringLiteral("keyboard"), false, QStringLiteral("device"), value);
+    else if (value == QStringLiteral("kvm")) appendPermission(entries, QObject::tr("Virtual machines"), QStringLiteral("developer_board"), true, QStringLiteral("device"), value);
+    else if (value == QStringLiteral("shm")) appendPermission(entries, QObject::tr("Shared memory"), QStringLiteral("memory"), false, QStringLiteral("device"), value);
 }
 
 void appendFilesystemPermission(QVariantList& entries, const QString& value) {
     QString path = value;
+    QString access;
     bool readOnly = false;
-    if (path.endsWith(QStringLiteral(":ro"))) {
-        path.chop(3);
-        readOnly = true;
-    } else if (path.endsWith(QStringLiteral(":rw")) || path.endsWith(QStringLiteral(":create"))) {
-        path = path.section(QLatin1Char(':'), 0, 0);
+
+    const qsizetype separator = path.lastIndexOf(QLatin1Char(':'));
+    if (separator > 0) {
+        access = path.mid(separator);
+        path = path.left(separator);
+        readOnly = access == QStringLiteral(":ro");
     }
 
     if (path == QStringLiteral("host")) {
-        appendPermission(entries, readOnly ? QObject::tr("All system files, read only") : QObject::tr("All system files"), QStringLiteral("folder_open"), !readOnly);
+        appendPermission(entries, readOnly ? QObject::tr("All system files, read only") : QObject::tr("All system files"),
+                         QStringLiteral("folder_open"), !readOnly, QStringLiteral("filesystem"), path, access);
     } else if (path == QStringLiteral("host-os")) {
-        appendPermission(entries, QObject::tr("System libraries and binaries"), QStringLiteral("folder_open"), true);
+        appendPermission(entries, QObject::tr("System libraries and binaries"), QStringLiteral("folder_open"), true, QStringLiteral("filesystem"), path, access);
     } else if (path == QStringLiteral("host-etc")) {
-        appendPermission(entries, QObject::tr("System configuration in /etc"), QStringLiteral("folder_open"), true);
+        appendPermission(entries, QObject::tr("System configuration in /etc"), QStringLiteral("folder_open"), true, QStringLiteral("filesystem"), path, access);
     } else if (path == QStringLiteral("home")) {
-        appendPermission(entries, readOnly ? QObject::tr("Your home folder, read only") : QObject::tr("Your home folder"), QStringLiteral("home"), !readOnly);
+        appendPermission(entries, readOnly ? QObject::tr("Your home folder, read only") : QObject::tr("Your home folder"),
+                         QStringLiteral("home"), !readOnly, QStringLiteral("filesystem"), path, access);
     } else if (path.startsWith(QStringLiteral("xdg-"))) {
-        appendPermission(entries, QObject::tr("Folder: %1").arg(path.mid(4)), QStringLiteral("folder"), false);
+        appendPermission(entries, QObject::tr("Folder: %1").arg(path.mid(4)), QStringLiteral("folder"), false, QStringLiteral("filesystem"), path, access);
     } else if (!path.isEmpty()) {
-        appendPermission(entries, QObject::tr("Path: %1").arg(path), QStringLiteral("folder"), !readOnly && !path.startsWith(QLatin1Char('~')));
+        appendPermission(entries, QObject::tr("Path: %1").arg(path), QStringLiteral("folder"),
+                         !readOnly && !path.startsWith(QLatin1Char('~')), QStringLiteral("filesystem"), path, access);
     }
 }
 
@@ -639,6 +697,29 @@ QVariantMap FlatpakPlugin::getDetails(const QString& packageId) {
 
         const QString runtime = metadata.value(QStringLiteral("runtimeName")).toString();
         if (!runtime.isEmpty()) map[QStringLiteral("runtime")] = runtime;
+    }
+
+    const QMap<QString, QStringList> overrides = getOverrides(packageId);
+    if (!overrides.isEmpty()) {
+        static const QMap<QString, QString> sections{
+            {QStringLiteral("shared"), QStringLiteral("shared")},
+            {QStringLiteral("socket"), QStringLiteral("sockets")},
+            {QStringLiteral("device"), QStringLiteral("devices")},
+            {QStringLiteral("filesystem"), QStringLiteral("filesystems")}
+        };
+
+        QVariantList permissions = map.value(QStringLiteral("permissions")).toList();
+        for (QVariant& value : permissions) {
+            QVariantMap entry = value.toMap();
+            const QString section = sections.value(entry.value(QStringLiteral("kind")).toString());
+            if (section.isEmpty()) continue;
+
+            if (overrides.value(section).contains(entry.value(QStringLiteral("value")).toString())) {
+                entry[QStringLiteral("revoked")] = true;
+                value = entry;
+            }
+        }
+        map[QStringLiteral("permissions")] = permissions;
     }
 
     if (map.value(QStringLiteral("permissions")).toList().isEmpty()) {

--- a/src/marketplace/plugins/flatpakplugin.hpp
+++ b/src/marketplace/plugins/flatpakplugin.hpp
@@ -2,6 +2,7 @@
 
 #include "packageplugin.hpp"
 #include <QJsonObject>
+#include <QMap>
 #include <QSet>
 #include <QSettings>
 
@@ -41,6 +42,10 @@ public:
 
     static QVariantList permissionEntries(const QJsonObject& permissions);
     static QVariantList parseLocalPermissions(const QString& output);
+    static QMap<QString, QStringList> parseOverrides(const QString& output);
+
+    QMap<QString, QStringList> getOverrides(const QString& packageId);
+    bool setPermission(const QString& packageId, const QString& kind, const QString& value, const QString& access, bool enabled);
     static QString formatBytes(qint64 bytes);
 
     static QString scopeArgument(const QString& scope);

--- a/translations/foundry_de.ts
+++ b/translations/foundry_de.ts
@@ -149,12 +149,12 @@
     </message>
     <message>
         <location line="+97" />
-        <location line="+304" />
+        <location line="+324" />
         <source>Download Size</source>
         <translation>Downloadgröße</translation>
     </message>
     <message>
-        <location line="-280" />
+        <location line="-300" />
         <source>Community</source>
         <translation>Community</translation>
     </message>
@@ -165,12 +165,12 @@
     </message>
     <message>
         <location line="+30" />
-        <location line="+231" />
+        <location line="+251" />
         <source>Installed Size</source>
         <translation>Installierte Größe</translation>
     </message>
     <message>
-        <location line="-204" />
+        <location line="-224" />
         <source>Everyone</source>
         <translation>Alle Altersgruppen</translation>
     </message>
@@ -200,12 +200,22 @@
         <translation>Berechtigungen</translation>
     </message>
     <message>
-        <location line="+8" />
+        <location line="+9" />
+        <source>What this application is allowed to access outside its sandbox. Turning one off adds a permission override for your user.</source>
+        <translation>Worauf diese Anwendung außerhalb ihrer Sandbox zugreifen darf. Ausschalten legt eine Berechtigungs-Ausnahme für den eigenen Benutzer an.</translation>
+    </message>
+    <message>
+        <location line="+1" />
         <source>What this application is allowed to access outside its sandbox.</source>
         <translation>Worauf diese Anwendung außerhalb ihrer Sandbox zugreifen darf.</translation>
     </message>
     <message>
-        <location line="+56" />
+        <location line="+29" />
+        <source>%1 (revoked)</source>
+        <translation>%1 (entzogen)</translation>
+    </message>
+    <message>
+        <location line="+45" />
         <source>Information</source>
         <translation>Informationen</translation>
     </message>
@@ -886,7 +896,7 @@
         <translation>%1 konnte nicht entfernt werden</translation>
     </message>
     <message>
-        <location line="+113" />
+        <location line="+132" />
         <source>Added remote %1</source>
         <translation>Remote %1 hinzugefügt</translation>
     </message>
@@ -1000,7 +1010,7 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/marketplace/plugins/flatpakplugin.cpp" line="+469" />
+        <location filename="../src/marketplace/plugins/flatpakplugin.cpp" line="+522" />
         <source>Network access</source>
         <translation>Netzwerkzugriff</translation>
     </message>
@@ -1075,7 +1085,7 @@
         <translation>Gemeinsamer Speicher</translation>
     </message>
     <message>
-        <location line="+14" />
+        <location line="+16" />
         <source>All system files, read only</source>
         <translation>Alle Systemdateien, nur lesend</translation>
     </message>
@@ -1085,7 +1095,7 @@
         <translation>Alle Systemdateien</translation>
     </message>
     <message>
-        <location line="+2" />
+        <location line="+3" />
         <source>System libraries and binaries</source>
         <translation>Systembibliotheken und -programme</translation>
     </message>
@@ -1105,7 +1115,7 @@
         <translation>Persönlicher Ordner</translation>
     </message>
     <message>
-        <location line="+2" />
+        <location line="+3" />
         <source>Folder: %1</source>
         <translation>Ordner: %1</translation>
     </message>


### PR DESCRIPTION
## Problem

The permissions card added in #17 shows what an application is allowed to reach outside its sandbox — including the entries that give up isolation, such as X11, the session bus or the whole file system — but it is read only. Acting on it means `flatpak override` on the command line or installing Flatseal.

## Change

- Permission entries carry the flag they came from (`kind` = shared/socket/device/filesystem plus the value and the access suffix), so they can be turned back into an override.
- `FlatpakPlugin::getOverrides()` reads `flatpak override --user --show <id>` and marks every permission that a user override already revokes; `setPermission()` writes `--unshare/--nosocket/--nodevice/--nofilesystem` to revoke and the positive flag to grant again. Overrides are always user scoped, so no authentication is needed and system installations stay untouched.
- Installed applications get a switch per permission; a revoked permission is greyed out and labelled "… (revoked)". The card explains that turning one off writes an override for the current user.
- All new strings are translated.

## Testing

Driven through the plugin against the installed `com.nvidia.geforcenow` on this machine:

```
start:                (none)
revoke x11         -> true    sockets=[x11]
revoke host        -> true    filesystems=[host] sockets=[x11]
grant x11 back     -> true    filesystems=[host]
flatpak override --user --reset  -> clean
```

`getOverrides()` reports exactly what `flatpak override --show` contains, and the detail page renders the switches for an installed app (screenshot from the running app: network access and audio on, the two bus permissions marked as sensitive). Details for a non-installed app are unchanged and show no switches. `ctest` passes, and the user's overrides were reset afterwards.