### PR TITLE
feat(appimage): search and install from the AppImageHub catalogue

### DIFF
--- a/src/marketplace/plugins/appimageplugin.cpp
+++ b/src/marketplace/plugins/appimageplugin.cpp
@@ -2,14 +2,27 @@
 #include "appimageinstaller.hpp"
 #include "pluginprocess.hpp"
 
+#include <QEventLoop>
 #include <QFile>
 #include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMutexLocker>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
 #include <QProcess>
 #include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QSet>
 #include <QUrl>
 
 namespace {
 constexpr int kCheckTimeoutMs = 30000;
+constexpr int kCatalogTimeoutMs = 20000;
+constexpr int kMaxCatalogResults = 40;
 
 QString updateTool() {
     return QStandardPaths::findExecutable(QStringLiteral("appimageupdatetool"));
@@ -28,20 +41,215 @@ void AppImagePlugin::setEnabled(bool enabled) {
     }
 }
 
+QVariantList AppImagePlugin::parseCatalog(const QByteArray& payload) {
+    QVariantList entries;
+
+    const QJsonDocument document = QJsonDocument::fromJson(payload);
+    if (!document.isObject()) return entries;
+
+    const QJsonArray items = document.object().value(QStringLiteral("items")).toArray();
+    for (const QJsonValue& value : items) {
+        const QJsonObject item = value.toObject();
+        const QString name = item.value(QStringLiteral("name")).toString();
+        if (name.isEmpty()) continue;
+
+        QString repository;
+        QString releasePage;
+        for (const QJsonValue& linkValue : item.value(QStringLiteral("links")).toArray()) {
+            const QJsonObject link = linkValue.toObject();
+            const QString type = link.value(QStringLiteral("type")).toString();
+            if (type == QStringLiteral("GitHub")) repository = link.value(QStringLiteral("url")).toString();
+            else if (type == QStringLiteral("Download")) releasePage = link.value(QStringLiteral("url")).toString();
+        }
+        if (repository.isEmpty()) continue;
+
+        QVariantMap entry;
+        entry[QStringLiteral("id")] = name;
+        entry[QStringLiteral("name")] = name;
+        entry[QStringLiteral("summary")] = item.value(QStringLiteral("description")).toString();
+        entry[QStringLiteral("backend")] = QStringLiteral("AppImage");
+        entry[QStringLiteral("scope")] = QStringLiteral("user");
+        entry[QStringLiteral("repository")] = QStringLiteral("AppImageHub");
+        entry[QStringLiteral("catalog")] = true;
+        entry[QStringLiteral("githubRepository")] = repository;
+        entry[QStringLiteral("homepage")] = QStringLiteral("https://github.com/") + repository;
+        entry[QStringLiteral("releasePage")] = releasePage;
+
+        const QJsonArray icons = item.value(QStringLiteral("icons")).toArray();
+        entry[QStringLiteral("icon")] = icons.isEmpty()
+            ? name
+            : QStringLiteral("https://appimage.github.io/database/") + icons.first().toString();
+
+        const QJsonArray authors = item.value(QStringLiteral("authors")).toArray();
+        if (!authors.isEmpty()) entry[QStringLiteral("developer")] = authors.first().toObject().value(QStringLiteral("name")).toString();
+
+        const QString license = item.value(QStringLiteral("license")).toString();
+        if (!license.isEmpty()) entry[QStringLiteral("license")] = license.section(QLatin1Char('='), 0, 0);
+
+        entries.append(entry);
+    }
+    return entries;
+}
+
+QVariantList AppImagePlugin::getCatalog() {
+    QMutexLocker locker(&m_catalogMutex);
+    if (m_catalogLoaded) return m_catalog;
+    locker.unlock();
+
+    QNetworkAccessManager manager;
+    QNetworkRequest request(QUrl(QStringLiteral("https://appimage.github.io/feed.json")));
+    request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("astra-foundry/1.0"));
+    request.setTransferTimeout(kCatalogTimeoutMs);
+
+    QEventLoop loop;
+    QNetworkReply* reply = manager.get(request);
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    QVariantList entries;
+    if (reply->error() == QNetworkReply::NoError) entries = parseCatalog(reply->readAll());
+    reply->deleteLater();
+
+    locker.relock();
+    if (!entries.isEmpty()) {
+        m_catalog = entries;
+        m_catalogLoaded = true;
+    }
+    return m_catalog;
+}
+
+QVariantMap AppImagePlugin::catalogEntry(const QString& packageId) {
+    const QVariantList catalog = getCatalog();
+    for (const QVariant& value : catalog) {
+        const QVariantMap entry = value.toMap();
+        if (entry.value(QStringLiteral("id")).toString().compare(packageId, Qt::CaseInsensitive) == 0) return entry;
+    }
+    return {};
+}
+
+QString AppImagePlugin::pickReleaseAsset(const QByteArray& payload, QString* fileName) {
+    const QJsonDocument document = QJsonDocument::fromJson(payload);
+    if (!document.isObject()) return QString();
+
+    QString fallbackUrl;
+    QString fallbackName;
+
+    for (const QJsonValue& value : document.object().value(QStringLiteral("assets")).toArray()) {
+        const QJsonObject asset = value.toObject();
+        const QString name = asset.value(QStringLiteral("name")).toString();
+        if (!name.endsWith(QLatin1String(".appimage"), Qt::CaseInsensitive)) continue;
+
+        const QString url = asset.value(QStringLiteral("browser_download_url")).toString();
+        const QString lowered = name.toLower();
+        if (lowered.contains(QStringLiteral("aarch64")) || lowered.contains(QStringLiteral("arm64")) || lowered.contains(QStringLiteral("armhf"))) continue;
+
+        if (lowered.contains(QStringLiteral("x86_64")) || lowered.contains(QStringLiteral("amd64"))) {
+            if (fileName) *fileName = name;
+            return url;
+        }
+
+        if (fallbackUrl.isEmpty()) {
+            fallbackUrl = url;
+            fallbackName = name;
+        }
+    }
+
+    if (fileName) *fileName = fallbackName;
+    return fallbackUrl;
+}
+
+QString AppImagePlugin::resolveDownloadUrl(const QString& repository, QString* fileName) {
+    if (repository.isEmpty()) return QString();
+
+    QNetworkAccessManager manager;
+    QNetworkRequest request(QUrl(QStringLiteral("https://api.github.com/repos/") + repository + QStringLiteral("/releases/latest")));
+    request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("astra-foundry/1.0"));
+    request.setRawHeader("Accept", "application/vnd.github+json");
+    request.setTransferTimeout(kCatalogTimeoutMs);
+
+    QEventLoop loop;
+    QNetworkReply* reply = manager.get(request);
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    QString url;
+    if (reply->error() == QNetworkReply::NoError) url = pickReleaseAsset(reply->readAll(), fileName);
+    reply->deleteLater();
+    return url;
+}
+
+QString AppImagePlugin::downloadRelease(const QString& url, const QString& fileName, ProgressCallback progressCb) {
+    QTemporaryDir temporaryDir;
+    temporaryDir.setAutoRemove(false);
+    if (!temporaryDir.isValid()) return QString();
+
+    const QString target = temporaryDir.path() + QStringLiteral("/") + (fileName.isEmpty() ? QStringLiteral("download.AppImage") : fileName);
+    QFile file(target);
+    if (!file.open(QIODevice::WriteOnly)) return QString();
+
+    QNetworkAccessManager manager;
+    QNetworkRequest request{QUrl(url)};
+    request.setHeader(QNetworkRequest::UserAgentHeader, QStringLiteral("astra-foundry/1.0"));
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    QEventLoop loop;
+    QNetworkReply* reply = manager.get(request);
+
+    QObject::connect(reply, &QNetworkReply::readyRead, reply, [&file, reply, this] {
+        file.write(reply->readAll());
+        if (m_cancellation && m_cancellation->isCancelled()) reply->abort();
+    });
+    QObject::connect(reply, &QNetworkReply::downloadProgress, reply, [&progressCb, fileName](qint64 received, qint64 total) {
+        if (!progressCb || total <= 0) return;
+        const int percent = static_cast<int>((received * 100) / total);
+        progressCb(percent, QObject::tr("Downloading %1 (%2%)").arg(fileName, QString::number(percent)));
+    });
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    const bool failed = reply->error() != QNetworkReply::NoError;
+    file.write(reply->readAll());
+    file.close();
+    reply->deleteLater();
+
+    if (failed) {
+        QFile::remove(target);
+        return QString();
+    }
+    return target;
+}
+
 QVariantList AppImagePlugin::search(const QString& query, const QVariantMap& options) {
     Q_UNUSED(options);
     QVariantList results;
     if (!m_enabled) return results;
 
     const QString needle = query.trimmed().toLower();
+    if (needle.isEmpty()) return results;
+
+    QSet<QString> seen;
     const QVariantList installed = getInstalled();
     for (const QVariant& value : installed) {
         const QVariantMap item = value.toMap();
-        if (item.value(QStringLiteral("name")).toString().toLower().contains(needle) ||
-            item.value(QStringLiteral("id")).toString().toLower().contains(needle)) {
+        const QString id = item.value(QStringLiteral("id")).toString();
+        if (item.value(QStringLiteral("name")).toString().toLower().contains(needle) || id.toLower().contains(needle)) {
+            seen.insert(id.toLower());
             results.append(item);
         }
     }
+
+    const QVariantList catalog = getCatalog();
+    for (const QVariant& value : catalog) {
+        if (results.size() >= kMaxCatalogResults) break;
+
+        const QVariantMap item = value.toMap();
+        const QString id = item.value(QStringLiteral("id")).toString();
+        if (seen.contains(id.toLower())) continue;
+        if (!id.toLower().contains(needle) && !item.value(QStringLiteral("summary")).toString().toLower().contains(needle)) continue;
+
+        results.append(item);
+    }
+
     return results;
 }
 
@@ -117,14 +325,27 @@ bool AppImagePlugin::update(const QString& packageId, const QVariantMap& options
 
 QVariantMap AppImagePlugin::getDetails(const QString& packageId) {
     QVariantMap map = AppImageInstaller::findInstalledAppImage(packageId);
+
+    if (map.isEmpty()) {
+        const QVariantMap entry = catalogEntry(packageId);
+        if (!entry.isEmpty()) {
+            map = entry;
+            map[QStringLiteral("description")] = entry.value(QStringLiteral("summary"));
+            map[QStringLiteral("version")] = tr("latest release");
+            return map;
+        }
+    }
+
     map[QStringLiteral("id")] = map.value(QStringLiteral("id"), packageId);
     map[QStringLiteral("name")] = map.value(QStringLiteral("name"), packageId);
     map[QStringLiteral("backend")] = QStringLiteral("AppImage");
     map[QStringLiteral("version")] = QStringLiteral("portable");
+    map[QStringLiteral("repository")] = QStringLiteral("local");
+    if (map.contains(QStringLiteral("size"))) map[QStringLiteral("installedSize")] = map.value(QStringLiteral("size"));
 
     const QString summary = map.value(QStringLiteral("summary")).toString();
     if (summary.isEmpty()) {
-        map[QStringLiteral("summary")] = QStringLiteral("Standalone AppImage application");
+        map[QStringLiteral("summary")] = tr("Standalone AppImage application");
     }
     map[QStringLiteral("description")] = map.value(QStringLiteral("path")).toString().isEmpty()
         ? map.value(QStringLiteral("summary"))
@@ -141,15 +362,41 @@ bool AppImagePlugin::install(const QString& packageId, const QVariantMap& option
     if (path.startsWith(QLatin1String("file://"))) path = QUrl(path).toLocalFile();
 
     const QFileInfo info(path);
-    if (!info.exists() || !info.isFile()) {
-        if (progressCb) progressCb(0, QStringLiteral("AppImage file not found: ") + path);
+    if (info.exists() && info.isFile()) {
+        if (progressCb) progressCb(10, tr("Installing %1").arg(info.fileName()));
+
+        AppImageInstaller installer;
+        const bool installed = installer.installAppImage(info.absoluteFilePath());
+        if (progressCb) progressCb(installed ? 100 : 0, installer.statusMessage());
+        return installed;
+    }
+
+    const QVariantMap entry = catalogEntry(packageId);
+    if (entry.isEmpty()) {
+        if (progressCb) progressCb(0, tr("No AppImage file and no catalogue entry for %1").arg(packageId));
         return false;
     }
 
-    if (progressCb) progressCb(10, QStringLiteral("Installing ") + info.fileName());
+    if (progressCb) progressCb(5, tr("Looking up the latest release of %1").arg(packageId));
+
+    QString fileName;
+    const QString downloadUrl = resolveDownloadUrl(entry.value(QStringLiteral("githubRepository")).toString(), &fileName);
+    if (downloadUrl.isEmpty()) {
+        if (progressCb) progressCb(0, tr("The latest release of %1 has no AppImage for this architecture").arg(packageId));
+        return false;
+    }
+
+    const QString downloaded = downloadRelease(downloadUrl, fileName, progressCb);
+    if (downloaded.isEmpty()) {
+        if (progressCb) progressCb(0, tr("Downloading %1 failed").arg(fileName));
+        return false;
+    }
+
+    if (progressCb) progressCb(100, tr("Installing %1").arg(fileName));
 
     AppImageInstaller installer;
-    const bool installed = installer.installAppImage(info.absoluteFilePath());
+    const bool installed = installer.installAppImage(downloaded);
+    QDir(QFileInfo(downloaded).absolutePath()).removeRecursively();
 
     if (progressCb) progressCb(installed ? 100 : 0, installer.statusMessage());
     return installed;

--- a/src/marketplace/plugins/appimageplugin.hpp
+++ b/src/marketplace/plugins/appimageplugin.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "packageplugin.hpp"
+#include <QMutex>
 #include <QSettings>
 
 class AppImagePlugin : public IPackagePlugin {
@@ -27,7 +28,19 @@ public:
     bool update(const QString& packageId, const QVariantMap& options = {}, ProgressCallback progressCb = nullptr) override;
     bool launch(const QString& packageId) override;
 
+    QVariantList getCatalog();
+
+    static QVariantList parseCatalog(const QByteArray& payload);
+    static QString pickReleaseAsset(const QByteArray& payload, QString* fileName);
+
 private:
+    QVariantMap catalogEntry(const QString& packageId);
+    QString resolveDownloadUrl(const QString& repository, QString* fileName);
+    QString downloadRelease(const QString& url, const QString& fileName, ProgressCallback progressCb);
+
     bool m_enabled{true};
+    bool m_catalogLoaded{false};
+    QVariantList m_catalog;
+    QMutex m_catalogMutex;
     QSettings m_settings{QStringLiteral("astra-foundry"), QStringLiteral("Plugins")};
 };

--- a/translations/foundry_de.ts
+++ b/translations/foundry_de.ts
@@ -356,7 +356,7 @@
 <context>
     <name>AppImagePlugin</name>
     <message>
-        <location filename="../src/marketplace/plugins/appimageplugin.cpp" line="+84" />
+        <location filename="../src/marketplace/plugins/appimageplugin.cpp" line="+292" />
         <source>new version available</source>
         <translation>neue Version verfügbar</translation>
     </message>
@@ -369,6 +369,42 @@
         <location line="+7" />
         <source>No installed AppImage matches %1</source>
         <translation>Kein installiertes AppImage passt zu %1</translation>
+    </message>
+    <message>
+        <location line="+23" />
+        <source>latest release</source>
+        <translation>neueste Veröffentlichung</translation>
+    </message>
+    <message>
+        <location line="+14" />
+        <source>Standalone AppImage application</source>
+        <translation>Eigenständige AppImage-Anwendung</translation>
+    </message>
+    <message>
+        <location line="+18" />
+        <location line="+29" />
+        <source>Installing %1</source>
+        <translation>%1 wird installiert</translation>
+    </message>
+    <message>
+        <location line="-19" />
+        <source>No AppImage file and no catalogue entry for %1</source>
+        <translation>Keine AppImage-Datei und kein Katalogeintrag für %1</translation>
+    </message>
+    <message>
+        <location line="+4" />
+        <source>Looking up the latest release of %1</source>
+        <translation>Neueste Veröffentlichung von %1 wird gesucht</translation>
+    </message>
+    <message>
+        <location line="+5" />
+        <source>The latest release of %1 has no AppImage for this architecture</source>
+        <translation>Die neueste Veröffentlichung von %1 enthält kein AppImage für diese Architektur</translation>
+    </message>
+    <message>
+        <location line="+6" />
+        <source>Downloading %1 failed</source>
+        <translation>Herunterladen von %1 fehlgeschlagen</translation>
     </message>
 </context>
 <context>
@@ -1123,6 +1159,11 @@
         <location line="+2" />
         <source>Path: %1</source>
         <translation>Pfad: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/marketplace/plugins/appimageplugin.cpp" line="-186" />
+        <source>Downloading %1 (%2%)</source>
+        <translation>%1 wird heruntergeladen (%2 %)</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Problem

`AppImagePlugin::search()` filters the *installed* AppImages, so the source can only ever show what the user already has. There is no way to discover an AppImage from inside the app — the only entry point is dragging a file onto the window.

## Change

- `getCatalog()` fetches the AppImageHub feed (`https://appimage.github.io/feed.json`, 1421 applications) once per session and caches it; entries carry name, description, icon, upstream repository and licence.
- `search()` returns installed AppImages first and then matching catalogue entries, capped at 40 results, so AppImage results show up next to Flatpak, Pacman and AUR.
- `install()` on a catalogue entry resolves the latest GitHub release, picks the `.AppImage` asset for this architecture (preferring `x86_64`/`amd64`, skipping arm builds), downloads it into a temporary directory with progress reporting, and hands it to the existing `AppImageInstaller`, which extracts the icon and writes the desktop entry. A local path or `file://` URL keeps working exactly as before, and a cancelled operation aborts the download.
- `getDetails()` falls back to the catalogue for entries that are not installed, so the detail page shows the description, developer, licence and project page.

## Testing

Catalogue search on this machine:

```
$ astra search 86box --source AppImage --json
{'id': '86Box', 'icon': 'https://appimage.github.io/database/86Box/icons/512x512/86box.png',
 'githubRepository': '86Box/86Box', 'homepage': 'https://github.com/86Box/86Box'}
```

Full install of a real catalogue entry (3.7 MB, chosen for size), then removal:

```
$ astra install Znax --source AppImage
  Looking up the latest release of Znax
  Downloading znax-1.1-linux.x86_64.AppImage (0%)
  Downloading znax-1.1-linux.x86_64.AppImage (78%)
  Downloading znax-1.1-linux.x86_64.AppImage (100%)
  Installing znax-1.1-linux.x86_64.AppImage
Successfully installed Znax          (1.5 s)

~/.local/bin/znax-1-1-linux-x86_64.AppImage
~/.local/share/applications/appimage-znax-1-1-linux-x86_64.desktop
~/.local/share/icons/hicolor/512x512/apps/znax-1-1-linux-x86_64.svg

$ astra remove znax-1-1-linux-x86_64 --source AppImage   # all three gone
```

In the GUI a search for "86box" now lists the Flatpak, the AUR package and the AppImage catalogue entry with its icon side by side (screenshot from the running app). `ctest` passes, all new strings are translated.