### PR TITLE
chore(packaging): add the AUR PKGBUILDs to the repository

### DIFF
--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,38 @@
+# AUR packages
+
+Three packages cover the same application:
+
+| Package | Source |
+| --- | --- |
+| `astra-foundry` | builds from the release tarball |
+| `astra-foundry-bin` | the precompiled binary from the GitHub release |
+| `astra-foundry-git` | builds from `main` |
+
+All three provide `astra-foundry` and conflict with each other and with the old `astramarket*`
+packages, which they replace.
+
+## Releasing a new version
+
+For `astra-foundry` and `astra-foundry-bin`, bump `pkgver`, reset `pkgrel` to 1 and refresh the
+checksums — the release workflow publishes a `.sha256` next to every asset, or:
+
+```bash
+updpkgsums
+```
+
+`astra-foundry-git` needs no version bump, its `pkgver()` derives the version from `git describe`.
+
+Then regenerate the metadata and push to the AUR:
+
+```bash
+makepkg --printsrcinfo > .SRCINFO
+git commit -am "astra-foundry 1.2.0"
+git push
+```
+
+## Checking a package before pushing
+
+```bash
+makepkg -f            # builds the package in place
+namcap PKGBUILD *.pkg.tar.zst
+```

--- a/packaging/aur/astra-foundry-bin/PKGBUILD
+++ b/packaging/aur/astra-foundry-bin/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: DiM <dim@astrasuite.dev>
+
+pkgname=astra-foundry-bin
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="Unified package manager for Flatpak, Pacman, AUR and AppImage with a graphical and a command line interface (precompiled)"
+arch=('x86_64')
+url="https://github.com/AstraSuite/Foundry"
+license=('GPL-3.0-or-later')
+depends=('qt6-base' 'qt6-declarative' 'qt6-svg' 'hicolor-icon-theme')
+optdepends=('flatpak: Flatpak and Flathub packages'
+            'pacman-contrib: update checks for native packages'
+            'paru: AUR support'
+            'yay: AUR support'
+            'polkit: authentication for pacman operations'
+            'appimageupdatetool: AppImage updates'
+            'desktop-file-utils: AppImage desktop integration')
+provides=('astra-foundry')
+conflicts=('astra-foundry' 'astra-foundry-git' 'astramarket-bin')
+replaces=('astramarket-bin')
+source=("$url/releases/download/v$pkgver/astra-foundry-v$pkgver-linux-x86_64.tar.gz")
+sha256sums=('270296c6995f77fda20797efea47069791509a6cf95be368da5931cb1e1c7d84')
+
+package() {
+    cd "astra-foundry-v$pkgver-linux-x86_64"
+
+    install -Dm755 bin/astra "$pkgdir/usr/bin/astra"
+    install -Dm644 share/applications/astra.desktop "$pkgdir/usr/share/applications/astra.desktop"
+    install -Dm644 share/polkit-1/actions/com.astra-foundry.pacman.policy \
+        "$pkgdir/usr/share/polkit-1/actions/com.astra-foundry.pacman.policy"
+
+    local icon
+    for icon in share/icons/hicolor/scalable/apps/*.svg; do
+        install -Dm644 "$icon" "$pkgdir/usr/share/icons/hicolor/scalable/apps/$(basename "$icon")"
+    done
+
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/aur/astra-foundry-git/PKGBUILD
+++ b/packaging/aur/astra-foundry-git/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: DiM <dim@astrasuite.dev>
+
+pkgname=astra-foundry-git
+pkgver=1.2.0.r0.ge3af300
+pkgrel=1
+pkgdesc="Unified package manager for Flatpak, Pacman, AUR and AppImage with a graphical and a command line interface (git)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/AstraSuite/Foundry"
+license=('GPL-3.0-or-later')
+depends=('qt6-base' 'qt6-declarative' 'qt6-svg' 'hicolor-icon-theme')
+makedepends=('cmake' 'ninja' 'git' 'qt6-shadertools' 'qt6-tools')
+optdepends=('flatpak: Flatpak and Flathub packages'
+            'pacman-contrib: update checks for native packages'
+            'paru: AUR support'
+            'yay: AUR support'
+            'polkit: authentication for pacman operations'
+            'appimageupdatetool: AppImage updates'
+            'desktop-file-utils: AppImage desktop integration')
+provides=('astra-foundry')
+conflicts=('astra-foundry' 'astra-foundry-bin' 'astramarket-git')
+replaces=('astramarket-git')
+source=("$pkgname::git+$url.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "$pkgname"
+    git describe --long --tags --abbrev=7 2>/dev/null | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' ||
+        printf "0.r%s.g%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+}
+
+build() {
+    cmake -B build -S "$pkgname" -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr
+    cmake --build build
+}
+
+package() {
+    DESTDIR="$pkgdir" cmake --install build
+}

--- a/packaging/aur/astra-foundry/PKGBUILD
+++ b/packaging/aur/astra-foundry/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: DiM <dim@astrasuite.dev>
+
+pkgname=astra-foundry
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="Unified package manager for Flatpak, Pacman, AUR and AppImage with a graphical and a command line interface"
+arch=('x86_64' 'aarch64')
+url="https://github.com/AstraSuite/Foundry"
+license=('GPL-3.0-or-later')
+depends=('qt6-base' 'qt6-declarative' 'qt6-svg' 'hicolor-icon-theme')
+makedepends=('cmake' 'ninja' 'qt6-shadertools' 'qt6-tools')
+optdepends=('flatpak: Flatpak and Flathub packages'
+            'pacman-contrib: update checks for native packages'
+            'paru: AUR support'
+            'yay: AUR support'
+            'polkit: authentication for pacman operations'
+            'appimageupdatetool: AppImage updates'
+            'desktop-file-utils: AppImage desktop integration')
+provides=('astra-foundry')
+conflicts=('astra-foundry-bin' 'astra-foundry-git' 'astramarket')
+replaces=('astramarket')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('90525f7a292b4ea4d407a3919985568c4ec693442e24f83ad3cfb5db3c41afd4')
+
+build() {
+    cmake -B build -S "Foundry-$pkgver" -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr
+    cmake --build build
+}
+
+package() {
+    DESTDIR="$pkgdir" cmake --install build
+}


### PR DESCRIPTION
## Why

The AUR packages have to be recreated under the new name anyway, and keeping the recipes in the repository means a change to the install layout (the renamed icon and policy file, the shell completions, the translations) is visible in the same commit that causes it.

## Contents

`packaging/aur/` with three recipes and a short README covering the release steps:

| Package | Source | Verified |
| --- | --- | --- |
| `astra-foundry` | release tarball, built with CMake | builds, ships binary, desktop entry, icon, polkit action and the bash/zsh/fish completions |
| `astra-foundry-bin` | `astra-foundry-v1.2.0-linux-x86_64.tar.gz` from the release | builds, ships binary, desktop entry, icons, polkit action, LICENSE |
| `astra-foundry-git` | `main`, version from `git describe` | builds, resolved to `1.2.0.r14.ge3af300` |

All three `provide` `astra-foundry`, conflict with each other and `replace` the matching `astramarket*` package, so an upgrade path exists for anyone who installed the old name. Optional dependencies name what each one actually enables: flatpak, pacman-contrib for update checks, paru/yay, polkit, appimageupdatetool, desktop-file-utils.

## Testing

`makepkg -f --nodeps` builds all three packages on this machine, and `makepkg --printsrcinfo` produces valid metadata for each. Checksums are the published ones — the release `.sha256` for the binary tarball and the GitHub source tarball digest.

The AUR side still has to be done by hand: submit the three packages and file a merge request for the old `astramarket*` ones, since the AUR has no rename.